### PR TITLE
fix: update discussions link to organization discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question
-    url: https://github.com/wowemulation-dev/recast-rs/discussions
+    url: https://github.com/orgs/wowemulation-dev/discussions
     about: Ask questions in GitHub Discussions


### PR DESCRIPTION
## Summary

Repository level discussions are not used. We only use organization level discussions.

## Changes

- update discussions link to organization discussions
