### PR TITLE
chore(ci): optimize CI to only run jobs for changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detect which crates have changed
+  # Detect which files and crates have changed
   changed-files:
-    name: Detect changed crates
+    name: Detect changes
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
-      crates_changed: ${{ steps.list-changed-crates.outputs.crates_changed }}
-      any_crate_changed: ${{ steps.list-changed-crates.outputs.any_crate_changed }}
+      # Crate-level changes
+      crates_changed: ${{ steps.changes.outputs.crates_changed }}
+      any_crate_changed: ${{ steps.changes.outputs.any_crate_changed }}
+      # Category-level changes
+      rust_changed: ${{ steps.changes.outputs.rust_changed }}
+      deps_changed: ${{ steps.changes.outputs.deps_changed }}
+      ci_changed: ${{ steps.changes.outputs.ci_changed }}
+      wasm_crates_changed: ${{ steps.changes.outputs.wasm_crates_changed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -45,63 +51,86 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: |
-            Cargo.toml
-            Cargo.lock
-            crates/**
-          files_ignore: |
-            **/*.md
-            **/*.txt
-            **/benches/**
-            **/examples/**
+          files_yaml: |
+            rust:
+              - 'crates/**/*.rs'
+              - 'crates/**/Cargo.toml'
+            deps:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'deny.toml'
+            ci:
+              - '.github/workflows/**'
+            wasm_crates:
+              - 'crates/recast-common/**'
+              - 'crates/recast/**'
+            recast_common:
+              - 'crates/recast-common/**'
+            recast:
+              - 'crates/recast/**'
+            detour:
+              - 'crates/detour/**'
+            detour_crowd:
+              - 'crates/detour-crowd/**'
+            detour_tilecache:
+              - 'crates/detour-tilecache/**'
+            detour_dynamic:
+              - 'crates/detour-dynamic/**'
+            recast_cli:
+              - 'crates/recast-cli/**'
 
-      - name: List changed crates
-        id: list-changed-crates
+      - name: Determine changes
+        id: changes
         env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          RUST_CHANGED: ${{ steps.changed-files.outputs.rust_any_changed }}
+          DEPS_CHANGED: ${{ steps.changed-files.outputs.deps_any_changed }}
+          CI_CHANGED: ${{ steps.changed-files.outputs.ci_any_changed }}
+          WASM_CRATES_CHANGED: ${{ steps.changed-files.outputs.wasm_crates_any_changed }}
+          RECAST_COMMON_CHANGED: ${{ steps.changed-files.outputs.recast_common_any_changed }}
+          RECAST_CHANGED: ${{ steps.changed-files.outputs.recast_any_changed }}
+          DETOUR_CHANGED: ${{ steps.changed-files.outputs.detour_any_changed }}
+          DETOUR_CROWD_CHANGED: ${{ steps.changed-files.outputs.detour_crowd_any_changed }}
+          DETOUR_TILECACHE_CHANGED: ${{ steps.changed-files.outputs.detour_tilecache_any_changed }}
+          DETOUR_DYNAMIC_CHANGED: ${{ steps.changed-files.outputs.detour_dynamic_any_changed }}
+          RECAST_CLI_CHANGED: ${{ steps.changed-files.outputs.recast_cli_any_changed }}
         run: |
-          echo "Changed files: $ALL_CHANGED_FILES"
+          echo "Rust code changed: $RUST_CHANGED"
+          echo "Dependencies changed: $DEPS_CHANGED"
+          echo "CI changed: $CI_CHANGED"
+          echo "WASM crates changed: $WASM_CRATES_CHANGED"
 
-          # If no files changed, we still need to run tests (e.g., scheduled runs)
-          if [ -z "$ALL_CHANGED_FILES" ]; then
-            echo "No files changed, will test all crates"
-            echo "any_crate_changed=true" >> "$GITHUB_OUTPUT"
-            echo "crates_changed=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Output category-level changes
+          echo "rust_changed=$RUST_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "deps_changed=$DEPS_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "ci_changed=$CI_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "wasm_crates_changed=$WASM_CRATES_CHANGED" >> "$GITHUB_OUTPUT"
 
-          # Check if root Cargo.toml or Cargo.lock changed (affects all crates)
-          if echo "$ALL_CHANGED_FILES" | grep -E "^Cargo\.(toml|lock)$"; then
-            echo "Root Cargo files changed, will test all crates"
-            echo "any_crate_changed=true" >> "$GITHUB_OUTPUT"
-            echo "crates_changed=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check individual crate changes
+          # Build list of changed crates
           crates_changed=""
-          for crate_dir in crates/*/; do
-            crate=$(basename "$crate_dir")
-            if echo "$ALL_CHANGED_FILES" | grep -E "crates/$crate/"; then
-              crates_changed="$crates_changed $crate"
-            fi
-          done
+          [ "$RECAST_COMMON_CHANGED" == "true" ] && crates_changed="$crates_changed recast-common"
+          [ "$RECAST_CHANGED" == "true" ] && crates_changed="$crates_changed recast"
+          [ "$DETOUR_CHANGED" == "true" ] && crates_changed="$crates_changed detour"
+          [ "$DETOUR_CROWD_CHANGED" == "true" ] && crates_changed="$crates_changed detour-crowd"
+          [ "$DETOUR_TILECACHE_CHANGED" == "true" ] && crates_changed="$crates_changed detour-tilecache"
+          [ "$DETOUR_DYNAMIC_CHANGED" == "true" ] && crates_changed="$crates_changed detour-dynamic"
+          [ "$RECAST_CLI_CHANGED" == "true" ] && crates_changed="$crates_changed recast-cli"
 
-          # Remove leading space and output
           crates_changed=$(echo "$crates_changed" | xargs)
-          if [ -n "$crates_changed" ]; then
-            echo "Crates changed: $crates_changed"
+          echo "Crates changed: $crates_changed"
+          echo "crates_changed=$crates_changed" >> "$GITHUB_OUTPUT"
+
+          # Determine if any crate changed (including via dependency changes)
+          if [ "$RUST_CHANGED" == "true" ] || [ "$DEPS_CHANGED" == "true" ] || [ "$CI_CHANGED" == "true" ]; then
             echo "any_crate_changed=true" >> "$GITHUB_OUTPUT"
-            echo "crates_changed=$crates_changed" >> "$GITHUB_OUTPUT"
           else
-            echo "No crate changes detected"
             echo "any_crate_changed=false" >> "$GITHUB_OUTPUT"
-            echo "crates_changed=" >> "$GITHUB_OUTPUT"
           fi
 
-  # Quick checks that should fail fast
+  # Quick checks - only run if Rust code, deps, or CI changed
   quick-checks:
     name: Quick Checks
+    needs: changed-files
+    if: needs.changed-files.outputs.rust_changed == 'true' || needs.changed-files.outputs.deps_changed == 'true' || needs.changed-files.outputs.ci_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -132,9 +161,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets
 
-  # Dependency security and license checks
+  # Dependency security and license checks - only run if deps changed
   deny:
     name: Cargo Deny
+    needs: changed-files
+    if: needs.changed-files.outputs.deps_changed == 'true' || needs.changed-files.outputs.ci_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -146,7 +177,7 @@ jobs:
           command: check
           arguments: --all-features
 
-  # Main test suite with optimized matrix
+  # Main test suite - only run if code changed
   test:
     name: Test (${{ matrix.rust }} on ${{ matrix.os }})
     needs: [quick-checks, changed-files]
@@ -187,10 +218,13 @@ jobs:
         id: test-scope
         env:
           CRATES_CHANGED: ${{ needs.changed-files.outputs.crates_changed }}
+          DEPS_CHANGED: ${{ needs.changed-files.outputs.deps_changed }}
         run: |
-          if [ -z "$CRATES_CHANGED" ]; then
-            echo "Testing all crates (full workspace test)"
+          # If deps changed, test all crates
+          if [ "$DEPS_CHANGED" == "true" ] || [ -z "$CRATES_CHANGED" ]; then
+            echo "Testing all crates (dependency or CI change)"
             echo "test_args=--workspace" >> "$GITHUB_OUTPUT"
+            echo "test_all=true" >> "$GITHUB_OUTPUT"
           else
             echo "Testing only changed crates: $CRATES_CHANGED"
             args=""
@@ -198,37 +232,29 @@ jobs:
               args="$args -p $crate"
             done
             echo "test_args=$args" >> "$GITHUB_OUTPUT"
+            echo "test_all=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Test with default features
-      - name: Test default features (changed crates)
+      - name: Test default features
         run: cargo nextest run ${{ steps.test-scope.outputs.test_args }}
 
-      # Test with no default features (library crates only)
+      # Test with no default features (only when testing all or specific library crates changed)
       - name: Test no default features (library crates)
+        if: steps.test-scope.outputs.test_all == 'true' || contains(needs.changed-files.outputs.crates_changed, 'recast-common') || contains(needs.changed-files.outputs.crates_changed, 'recast') || contains(needs.changed-files.outputs.crates_changed, 'detour')
         run: |
-          cargo nextest run --no-default-features -p recast-common
-          cargo nextest run --no-default-features -p recast
-          cargo nextest run --no-default-features -p detour
-          cargo nextest run --no-default-features -p detour-crowd
-          cargo nextest run --no-default-features -p detour-tilecache
-          cargo nextest run --no-default-features -p detour-dynamic
+          cargo nextest run --no-default-features -p recast-common || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
+          cargo nextest run --no-default-features -p recast || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
+          cargo nextest run --no-default-features -p detour || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
+          cargo nextest run --no-default-features -p detour-crowd || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
+          cargo nextest run --no-default-features -p detour-tilecache || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
+          cargo nextest run --no-default-features -p detour-dynamic || { ec=$?; [ $ec -eq 4 ] && echo "No tests (OK)" || exit $ec; }
 
-      # Test each changed crate individually (only on stable Linux)
-      - name: Test individual changed crates
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && needs.changed-files.outputs.crates_changed != ''
-        env:
-          CRATES_CHANGED: ${{ needs.changed-files.outputs.crates_changed }}
-        run: |
-          for crate in $CRATES_CHANGED; do
-            echo "Testing $crate individually..."
-            # Exit code 4 from nextest means no tests to run, which is OK
-            cargo nextest run -p "$crate" || { ec=$?; [ $ec -eq 4 ] && echo "No tests in $crate (OK)" || exit $ec; }
-          done
-
-  # WASM compilation check
+  # WASM compilation check - only run if WASM-compatible crates changed
   wasm:
     name: WASM Compilation
+    needs: changed-files
+    if: needs.changed-files.outputs.wasm_crates_changed == 'true' || needs.changed-files.outputs.deps_changed == 'true' || needs.changed-files.outputs.ci_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -248,13 +274,16 @@ jobs:
           cache-all-crates: true
 
       - name: Check WASM compilation (recast-common)
-        run: |
-          # recast-common supports WASM with --no-default-features (no file I/O)
-          cargo check --target wasm32-unknown-unknown -p recast-common --no-default-features
+        run: cargo check --target wasm32-unknown-unknown -p recast-common --no-default-features
 
-  # Documentation build - runs in parallel
+      - name: Check WASM compilation (recast)
+        run: cargo check --target wasm32-unknown-unknown -p recast
+
+  # Documentation build - only run if code changed
   docs:
     name: Documentation
+    needs: changed-files
+    if: needs.changed-files.outputs.rust_changed == 'true' || needs.changed-files.outputs.deps_changed == 'true' || needs.changed-files.outputs.ci_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -280,9 +309,11 @@ jobs:
       - name: Check for broken links
         run: cargo doc --workspace --no-deps --document-private-items
 
-  # Coverage collection - runs in parallel
+  # Coverage collection - only run if code changed
   coverage:
     name: Code Coverage
+    needs: changed-files
+    if: needs.changed-files.outputs.rust_changed == 'true' || needs.changed-files.outputs.deps_changed == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -321,22 +352,65 @@ jobs:
   ci-success:
     name: CI Success
     if: always()
-    needs: [quick-checks, deny, test, docs, wasm, changed-files]
+    needs: [changed-files, quick-checks, deny, test, docs, wasm]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
+        env:
+          RUST_CHANGED: ${{ needs.changed-files.outputs.rust_changed }}
+          DEPS_CHANGED: ${{ needs.changed-files.outputs.deps_changed }}
+          CI_CHANGED: ${{ needs.changed-files.outputs.ci_changed }}
+          ANY_CRATE_CHANGED: ${{ needs.changed-files.outputs.any_crate_changed }}
+          QUICK_CHECKS_RESULT: ${{ needs.quick-checks.result }}
+          DENY_RESULT: ${{ needs.deny.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          WASM_RESULT: ${{ needs.wasm.result }}
         run: |
-          # Skip test job check if no crates changed
-          if [[ "${{ needs.changed-files.outputs.any_crate_changed }}" == "false" ]]; then
-            echo "No crate changes detected, skipping test job check"
-            if [[ "${{ needs.quick-checks.result }}" == "failure" || "${{ needs.deny.result }}" == "failure" || "${{ needs.docs.result }}" == "failure" || "${{ needs.wasm.result }}" == "failure" ]]; then
-              echo "Quick checks, deny, docs, or WASM check failed"
-              exit 1
-            fi
-          else
-            if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-              echo "One or more jobs failed"
-              exit 1
-            fi
+          echo "Change detection:"
+          echo "  Rust changed: $RUST_CHANGED"
+          echo "  Deps changed: $DEPS_CHANGED"
+          echo "  CI changed: $CI_CHANGED"
+          echo "  Any crate changed: $ANY_CRATE_CHANGED"
+          echo ""
+          echo "Job results:"
+          echo "  quick-checks: $QUICK_CHECKS_RESULT"
+          echo "  deny: $DENY_RESULT"
+          echo "  test: $TEST_RESULT"
+          echo "  docs: $DOCS_RESULT"
+          echo "  wasm: $WASM_RESULT"
+
+          # Check for failures (skipped jobs are OK)
+          failed=false
+
+          if [[ "$QUICK_CHECKS_RESULT" == "failure" ]]; then
+            echo "quick-checks failed"
+            failed=true
           fi
-          echo "All required jobs succeeded"
+
+          if [[ "$DENY_RESULT" == "failure" ]]; then
+            echo "deny failed"
+            failed=true
+          fi
+
+          if [[ "$TEST_RESULT" == "failure" ]]; then
+            echo "test failed"
+            failed=true
+          fi
+
+          if [[ "$DOCS_RESULT" == "failure" ]]; then
+            echo "docs failed"
+            failed=true
+          fi
+
+          if [[ "$WASM_RESULT" == "failure" ]]; then
+            echo "wasm failed"
+            failed=true
+          fi
+
+          if [[ "$failed" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+
+          echo "All required jobs succeeded (or were skipped)"


### PR DESCRIPTION
## Summary

Add granular change detection to skip unnecessary CI jobs.

This reduces CI time and resource usage when only non-code files (like markdown) are modified.

## Changes

- quick-checks: only runs if Rust code, deps, or CI files change
- deny: only runs if dependency files change
- test: only tests changed crates (or all if deps change)
- wasm: only runs if WASM-compatible crates change
- docs: only runs if Rust code changes
- coverage: only runs if Rust code changes
