### PR TITLE
feat(detour): verify and document WASM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             wasm_crates:
               - 'crates/recast-common/**'
               - 'crates/recast/**'
+              - 'crates/detour/**'
             recast_common:
               - 'crates/recast-common/**'
             recast:
@@ -278,6 +279,9 @@ jobs:
 
       - name: Check WASM compilation (recast)
         run: cargo check --target wasm32-unknown-unknown -p recast
+
+      - name: Check WASM compilation (detour)
+        run: cargo check --target wasm32-unknown-unknown -p detour
 
   # Documentation build - only run if code changed
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `std::time::Instant` with `web-time` crate for WASM compatibility
 - `RecastContext` timing now works on both native and WASM targets
 
+#### detour
+
+- Verified WASM compatibility (file I/O already feature-gated behind `serialization`)
+- Added to CI WASM compilation checks
+
 ### Added
 
 #### recast-common


### PR DESCRIPTION
## Summary

Mark `detour` crate as WASM-compatible:

- File I/O operations are feature-gated behind `serialization`
- std::io types (Cursor, Read, Write) work on WASM
- 
## Changes

- Add detour to CI WASM compilation checks
- Update CHANGELOG to document WASM compatibility
