### PR TITLE
feat(wasm): verify detour-crowd WASM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
               - 'crates/recast-common/**'
               - 'crates/recast/**'
               - 'crates/detour/**'
+              - 'crates/detour-crowd/**'
             recast_common:
               - 'crates/recast-common/**'
             recast:
@@ -282,6 +283,9 @@ jobs:
 
       - name: Check WASM compilation (detour)
         run: cargo check --target wasm32-unknown-unknown -p detour
+
+      - name: Check WASM compilation (detour-crowd)
+        run: cargo check --target wasm32-unknown-unknown -p detour-crowd
 
   # Documentation build - only run if code changed
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified WASM compatibility (file I/O already feature-gated behind `serialization`)
 - Added to CI WASM compilation checks
 
+#### detour-crowd
+
+- Verified WASM compatibility (no WASM-incompatible dependencies)
+- Added to CI WASM compilation checks
+
 ### Added
 
 #### recast-common


### PR DESCRIPTION
## Summary

Marked `detour-crowd` as ready for WASM usage.

## Changes

- Verified detour-crowd compiles for wasm32-unknown-unknown target
- No WASM-incompatible dependencies (fastrand is WASM-compatible)
- std::time::Instant usage only in test code (not compiled for WASM)
- Added detour-crowd to CI WASM compilation checks