### PR TITLE
feat(wasm): improve detour-tilecache WASM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
               - 'crates/recast/**'
               - 'crates/detour/**'
               - 'crates/detour-crowd/**'
+              - 'crates/detour-tilecache/**'
             recast_common:
               - 'crates/recast-common/**'
             recast:
@@ -286,6 +287,9 @@ jobs:
 
       - name: Check WASM compilation (detour-crowd)
         run: cargo check --target wasm32-unknown-unknown -p detour-crowd
+
+      - name: Check WASM compilation (detour-tilecache)
+        run: cargo check --target wasm32-unknown-unknown -p detour-tilecache
 
   # Documentation build - only run if code changed
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified WASM compatibility (no WASM-incompatible dependencies)
 - Added to CI WASM compilation checks
 
+#### detour-tilecache
+
+- Replaced `lz4` crate with `lz4_flex` (pure Rust, no C dependencies)
+- File I/O functions already feature-gated behind `serialization`
+- In-memory serialization methods work on WASM
+- Added to CI WASM compilation checks
+
 ### Added
 
 #### recast-common

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,16 +113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
-name = "cc"
-version = "1.2.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,7 +261,7 @@ dependencies = [
  "detour",
  "glam",
  "log",
- "lz4",
+ "lz4_flex",
  "postcard",
  "recast",
  "recast-common",
@@ -314,12 +304,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "getrandom"
@@ -419,25 +403,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lz4"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
-dependencies = [
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "lz4_flex"
@@ -712,12 +677,6 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ serde_json = "1.0"
 postcard = { version = "1.1", features = ["alloc"] }
 
 # Compression
-lz4 = "1.28"
 lz4_flex = "0.11"
 
 # Testing

--- a/crates/detour-tilecache/Cargo.toml
+++ b/crates/detour-tilecache/Cargo.toml
@@ -17,7 +17,7 @@ detour = { workspace = true }
 glam = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
-lz4 = { workspace = true }
+lz4_flex = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 postcard = { workspace = true, optional = true }


### PR DESCRIPTION

## Summary

The lz4_flex crate is a pure Rust implementation that is no_std compatible and works seamlessly on WASM without any C compilation requirements. This now marks `detour-tilecache` as WASM compatible, too.

## Changes

- Replaced `lz4` crate with `lz4_flex` (pure Rust, no C dependencies)
- Removed `lz4` from workspace dependencies
- File I/O functions already gated behind `serialization` feature
- In-memory serialization methods work on WASM
- Added detour-tilecache to CI WASM compilation checks