### PR TITLE
docs: advertise WASM support in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Rust port of [RecastNavigation](https://github.com/recastnavigation/recastnavi
 
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](LICENSE-MIT)
 [![Rust Version](https://img.shields.io/badge/rust-1.85+-orange.svg)](https://www.rust-lang.org)
+[![WASM Compatible](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 > **Note**: This port is developed for the [WoW Emulation project][wowemu] and
 > has not been used outside of that context. The API may change as the project
@@ -18,20 +19,15 @@ It is a Rust 2024 edition port of Mikko Mononen's RecastNavigation C++ library.
 
 ## Workspace Structure
 
-```text
-recast-rs/
-├── crates/
-│   ├── recast-common/      # Shared utilities, math, error types
-│   ├── recast/             # Navigation mesh generation
-│   ├── detour/             # Pathfinding and navigation queries
-│   ├── detour-crowd/       # Multi-agent crowd simulation
-│   ├── detour-tilecache/   # Dynamic obstacle management
-│   ├── detour-dynamic/     # Dynamic navmesh support
-│   └── recast-cli/         # Command-line tool
-├── examples/               # Example applications
-├── benches/                # Performance benchmarks
-└── tests/                  # Integration tests
-```
+| Crate | Description | WASM |
+|-------|-------------|------|
+| `recast-common` | Shared utilities, math, error types | Yes |
+| `recast` | Navigation mesh generation | Yes |
+| `detour` | Pathfinding and navigation queries | Yes |
+| `detour-crowd` | Multi-agent crowd simulation | Yes |
+| `detour-tilecache` | Dynamic obstacle management | Yes |
+| `detour-dynamic` | Dynamic navmesh support | Yes |
+| `recast-cli` | Command-line tool | No |
 
 ### Crate Dependencies
 
@@ -124,7 +120,7 @@ cargo build --release
 
 - `serialization` - Save/load navigation meshes
 - `parallel` - Multi-threaded mesh generation (not WASM-compatible)
-- `async` - Async I/O operations (not WASM-compatible)
+- `tokio` - Tokio runtime integration for `detour-dynamic` (not WASM-compatible)
 
 ### Platform Support
 
@@ -132,6 +128,34 @@ cargo build --release
 - macOS (x86_64, aarch64)
 - Windows (x86_64)
 - WebAssembly (wasm32-unknown-unknown)
+
+## WebAssembly Support
+
+All library crates support WebAssembly (`wasm32-unknown-unknown`). Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p recast -p detour
+```
+
+### WASM-Compatible Features
+
+| Feature | Native | WASM | Notes |
+|---------|--------|------|-------|
+| Mesh generation | Yes | Yes | Full support |
+| Pathfinding | Yes | Yes | Full support |
+| Crowd simulation | Yes | Yes | Full support |
+| Dynamic obstacles | Yes | Yes | Full support |
+| Async operations | Yes | Yes | Runtime-agnostic via `async-lock` |
+| File I/O | Yes | No | Use `std` feature to disable |
+| Parallel processing | Yes | No | Disable `parallel` feature |
+| Serialization | Yes | Yes | In-memory only on WASM |
+
+### WASM Usage Notes
+
+- **recast-common**: Disable file I/O with `default-features = false`
+- **detour**: Serialization works with in-memory buffers
+- **detour-tilecache**: Uses pure Rust LZ4 (`lz4_flex`)
+- **detour-dynamic**: Async via `async-lock` and `futures-lite` (no tokio required)
 
 ## License
 

--- a/crates/detour-crowd/README.md
+++ b/crates/detour-crowd/README.md
@@ -5,6 +5,7 @@ Multi-agent crowd simulation on navigation meshes.
 [![Crates.io](https://img.shields.io/crates/v/detour-crowd.svg)](https://crates.io/crates/detour-crowd)
 [![Documentation](https://docs.rs/detour-crowd/badge.svg)](https://docs.rs/detour-crowd)
 [![License](https://img.shields.io/crates/l/detour-crowd.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -69,6 +70,14 @@ let velocity = agent.velocity();
 | `LocalBoundary` | Local obstacle detection |
 | `ObstacleAvoidance` | RVO collision avoidance |
 | `ProximityGrid` | Spatial indexing for neighbors |
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p detour-crowd
+```
 
 ## License
 

--- a/crates/detour-dynamic/README.md
+++ b/crates/detour-dynamic/README.md
@@ -5,6 +5,7 @@ Dynamic navigation mesh generation with real-time obstacle support.
 [![Crates.io](https://img.shields.io/crates/v/detour-dynamic.svg)](https://crates.io/crates/detour-dynamic)
 [![Documentation](https://docs.rs/detour-dynamic/badge.svg)](https://docs.rs/detour-dynamic)
 [![License](https://img.shields.io/crates/l/detour-dynamic.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -17,11 +18,15 @@ platforms, or procedurally generated content.
 
 - **Dynamic Obstacle Management**: Add and remove colliders at runtime
 - **Incremental Updates**: Only rebuild affected tiles for performance
-- **Async Processing**: Non-blocking navmesh updates using Tokio
+- **Async Processing**: Non-blocking navmesh updates (WASM-compatible)
 - **Multiple Collider Types**: Box, cylinder, sphere, trimesh, and composites
 - **Checkpoint System**: Efficient state management for incremental rebuilds
 - **Voxel-based Queries**: Precise raycasting against heightfield data
 - **Serialization**: Save and load dynamic navmesh state
+
+## Optional Features
+
+- `tokio` - Use Tokio runtime for async operations (not WASM-compatible)
 
 ## Collider Types
 
@@ -77,16 +82,37 @@ let query = navmesh.create_query()?;
 
 ## Async Updates
 
+Async operations use runtime-agnostic primitives (`async-lock`, `futures-lite`)
+and work on all platforms including WASM:
+
+```rust
+// Works with any async runtime (Tokio, async-std, wasm-bindgen-futures, etc.)
+navmesh.build_async().await?;
+navmesh.update_async().await?;
+```
+
+On native platforms with Tokio:
+
 ```rust
 use tokio::runtime::Runtime;
 
 let rt = Runtime::new()?;
 rt.block_on(async {
-    // Rebuild tiles asynchronously
-    navmesh.rebuild_dirty_tiles_async().await?;
+    navmesh.build_async().await?;
     Ok::<_, Box<dyn std::error::Error>>(())
 })?;
 ```
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p detour-dynamic
+```
+
+Async operations work on WASM using `wasm-bindgen-futures` or similar runtimes.
+The `tokio` feature is not available on WASM.
 
 ## License
 

--- a/crates/detour-tilecache/README.md
+++ b/crates/detour-tilecache/README.md
@@ -5,6 +5,7 @@ Dynamic obstacle management and tile caching for navigation meshes.
 [![Crates.io](https://img.shields.io/crates/v/detour-tilecache.svg)](https://crates.io/crates/detour-tilecache)
 [![Documentation](https://docs.rs/detour-tilecache/badge.svg)](https://docs.rs/detour-tilecache)
 [![License](https://img.shields.io/crates/l/detour-tilecache.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -75,6 +76,18 @@ tile_cache.update()?;
 | Cylinder | Circular base with height | Trees, pillars, characters |
 | Box | Axis-aligned box | Crates, furniture |
 | Oriented Box | Rotated box | Vehicles, angled objects |
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p detour-tilecache
+```
+
+LZ4 compression uses `lz4_flex`, a pure Rust implementation that works on WASM.
+Serialization works with in-memory buffers; file-based save/load is not
+available on WASM.
 
 ## License
 

--- a/crates/detour/README.md
+++ b/crates/detour/README.md
@@ -5,6 +5,7 @@ Pathfinding and spatial queries on navigation meshes.
 [![Crates.io](https://img.shields.io/crates/v/detour.svg)](https://crates.io/crates/detour)
 [![Documentation](https://docs.rs/detour/badge.svg)](https://docs.rs/detour)
 [![License](https://img.shields.io/crates/l/detour.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -29,6 +30,17 @@ This is a Rust port of the Detour component from [RecastNavigation][recast-cpp].
 ## Optional Features
 
 - `serialization` - Save/load navigation meshes via Serde
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p detour
+```
+
+The `serialization` feature works on WASM with in-memory buffers. File-based
+save/load is not available on WASM.
 
 ## Example
 

--- a/crates/recast-common/README.md
+++ b/crates/recast-common/README.md
@@ -5,6 +5,7 @@ Common utilities and types shared by the recast-rs workspace crates.
 [![Crates.io](https://img.shields.io/crates/v/recast-common.svg)](https://crates.io/crates/recast-common)
 [![Documentation](https://docs.rs/recast-common/badge.svg)](https://docs.rs/recast-common)
 [![License](https://img.shields.io/crates/l/recast-common.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -20,7 +21,13 @@ and related crates. It is not intended for direct use by end users.
 
 ## Features
 
-- `async` - Enables async runtime support via Tokio
+- `std` (default) - Enables file I/O operations (`TriMesh::from_obj()`)
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. For WASM builds, file I/O is
+automatically disabled. Use `TriMesh::from_obj_str()` to parse OBJ content from
+strings instead of files.
 
 ## Usage
 

--- a/crates/recast/README.md
+++ b/crates/recast/README.md
@@ -5,6 +5,7 @@ Navigation mesh generation from 3D triangle meshes.
 [![Crates.io](https://img.shields.io/crates/v/recast.svg)](https://crates.io/crates/recast)
 [![Documentation](https://docs.rs/recast/badge.svg)](https://docs.rs/recast)
 [![License](https://img.shields.io/crates/l/recast.svg)](../LICENSE-MIT)
+[![WASM](https://img.shields.io/badge/WASM-compatible-green.svg)](https://webassembly.org/)
 
 ## Overview
 
@@ -27,7 +28,18 @@ This is a Rust port of the Recast component from [RecastNavigation][recast-cpp].
 
 ## Optional Features
 
-- `parallel` - Multi-threaded mesh generation using Rayon
+- `parallel` - Multi-threaded mesh generation using Rayon (not WASM-compatible)
+
+## WASM Support
+
+This crate is fully compatible with WebAssembly. Build for WASM with:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p recast
+```
+
+Note: The `parallel` feature is not available on WASM. Timing uses `web-time`
+for cross-platform compatibility.
 
 ## Example
 


### PR DESCRIPTION
## Summary

Advertise WASM support where applicable.

## Changes

Update main README:

- Add WASM badge
- Replace workspace structure with table showing WASM compatibility
- Add dedicated WASM section with feature matrix and usage notes

Update crate READMEs:

- recast-common: Add WASM badge and section (std feature for file I/O)
- recast: Add WASM badge and section (parallel not WASM-compatible)
- detour: Add WASM badge and section (serialization works in-memory)
- detour-crowd: Add WASM badge and section
- detour-tilecache: Add WASM badge and section (lz4_flex for compression)
- detour-dynamic: Add WASM badge and section (runtime-agnostic async)