### PR TITLE
perf(recast): replace HashMap+Rc/RefCell heightfield with flat Vec arena

### DIFF
--- a/crates/detour-dynamic/src/checkpoint.rs
+++ b/crates/detour-dynamic/src/checkpoint.rs
@@ -1,7 +1,5 @@
 use recast::Heightfield;
-use std::cell::RefCell;
 use std::collections::HashSet;
-use std::rc::Rc;
 
 /// Checkpoint system for saving and restoring heightfield states
 ///
@@ -37,27 +35,19 @@ impl DynamicTileCheckpoint {
             source.ch(),
         );
 
-        // Clone all spans
+        // Clone all spans column by column
         for z in 0..source.height() {
             for x in 0..source.width() {
-                if let Some(Some(span_rc)) = source.spans().get(&(x, z)) {
-                    Self::clone_span_chain(&mut clone, x, z, span_rc.clone());
+                let mut si = source.column_first_span(x, z);
+                while si != recast::SPAN_NULL {
+                    let s = source.span(si);
+                    let _ = clone.add_span(x, z, s.min, s.max, s.area);
+                    si = s.next;
                 }
             }
         }
 
         clone
-    }
-
-    /// Recursively clones a chain of spans
-    fn clone_span_chain(target: &mut Heightfield, x: i32, z: i32, span: Rc<RefCell<recast::Span>>) {
-        let span_borrow = span.borrow();
-        let _ = target.add_span(x, z, span_borrow.min, span_borrow.max, span_borrow.area);
-
-        // Clone next span in the chain if it exists
-        if let Some(next_span) = &span_borrow.next {
-            Self::clone_span_chain(target, x, z, next_span.clone());
-        }
     }
 
     /// Checks if this checkpoint can be used for the given set of colliders
@@ -75,9 +65,9 @@ impl DynamicTileCheckpoint {
         // Add heightfield memory
         size += std::mem::size_of::<Heightfield>();
 
-        // Estimate span memory (this is approximate)
-        size += self.heightfield.spans().len() * std::mem::size_of::<(i32, i32)>();
-        size += self.heightfield.spans().len() * 64; // Approximate span memory
+        // Estimate span memory
+        size += self.heightfield.columns().len() * std::mem::size_of::<u32>();
+        size += self.heightfield.spans_arena().len() * std::mem::size_of::<recast::SpanEntry>();
 
         // Add collider set memory
         size += self.colliders.len() * std::mem::size_of::<u64>();

--- a/crates/detour-dynamic/src/io/voxel_tile.rs
+++ b/crates/detour-dynamic/src/io/voxel_tile.rs
@@ -75,13 +75,11 @@ impl VoxelTile {
         for z in 0..heightfield.height() {
             for x in 0..heightfield.width() {
                 let index = (z * heightfield.width() + x) as usize;
-                if let Some(span_rc) = heightfield.spans().get(&(x, z)).and_then(|s| s.as_ref()) {
-                    let mut current_span = Some(span_rc.clone());
-                    while let Some(span) = current_span {
-                        counts[index] += 1;
-                        total_count += 1;
-                        current_span = span.borrow().next.clone();
-                    }
+                let mut si = heightfield.column_first_span(x, z);
+                while si != recast::SPAN_NULL {
+                    counts[index] += 1;
+                    total_count += 1;
+                    si = heightfield.span(si).next;
                 }
             }
         }
@@ -99,15 +97,13 @@ impl VoxelTile {
                 data.extend_from_slice(&counts[index].to_be_bytes());
 
                 // Write spans
-                if let Some(span_rc) = heightfield.spans().get(&(x, z)).and_then(|s| s.as_ref()) {
-                    let mut current_span = Some(span_rc.clone());
-                    while let Some(span) = current_span {
-                        let span_ref = span.borrow();
-                        data.extend_from_slice(&(span_ref.min as u32).to_be_bytes());
-                        data.extend_from_slice(&(span_ref.max as u32).to_be_bytes());
-                        data.extend_from_slice(&(span_ref.area as u32).to_be_bytes());
-                        current_span = span_ref.next.clone();
-                    }
+                let mut si = heightfield.column_first_span(x, z);
+                while si != recast::SPAN_NULL {
+                    let s = heightfield.span(si);
+                    data.extend_from_slice(&(s.min as u32).to_be_bytes());
+                    data.extend_from_slice(&(s.max as u32).to_be_bytes());
+                    data.extend_from_slice(&(s.area as u32).to_be_bytes());
+                    si = s.next;
                 }
             }
         }

--- a/crates/detour-dynamic/src/voxel_query.rs
+++ b/crates/detour-dynamic/src/voxel_query.rs
@@ -252,32 +252,30 @@ impl VoxelQuery {
                 let y_max = (y1.max(y2) / heightfield.ch()).ceil();
 
                 // Check spans in this cell
-                if let Some(Some(span_rc)) = heightfield.spans().get(&(current_x, current_z)) {
-                    let mut current_span = Some(span_rc.clone());
-                    while let Some(span) = current_span {
-                        let span_ref = span.borrow();
-                        let span_min = span_ref.min as f32;
-                        let span_max = span_ref.max as f32;
+                let mut si = heightfield.column_first_span(current_x, current_z);
+                while si != recast::SPAN_NULL {
+                    let s = heightfield.span(si);
+                    let span_min = s.min as f32;
+                    let span_max = s.max as f32;
 
-                        // Check if ray intersects this span
-                        if span_min <= y_max && span_max >= y_min {
-                            let hit_t = (t_min + t).min(1.0);
-                            let hit_pos = Vec3::new(
-                                start.x + hit_t * tx,
-                                start.y + hit_t * ty,
-                                start.z + hit_t * tz,
-                            );
+                    // Check if ray intersects this span
+                    if span_min <= y_max && span_max >= y_min {
+                        let hit_t = (t_min + t).min(1.0);
+                        let hit_pos = Vec3::new(
+                            start.x + hit_t * tx,
+                            start.y + hit_t * ty,
+                            start.z + hit_t * tz,
+                        );
 
-                            return Some(VoxelRaycastHit {
-                                t: hit_t,
-                                position: hit_pos,
-                                cell_x: current_x,
-                                cell_z: current_z,
-                            });
-                        }
-
-                        current_span = span_ref.next.clone();
+                        return Some(VoxelRaycastHit {
+                            t: hit_t,
+                            position: hit_pos,
+                            cell_x: current_x,
+                            cell_z: current_z,
+                        });
                     }
+
+                    si = s.next;
                 }
             }
 

--- a/crates/recast/src/compact_heightfield.rs
+++ b/crates/recast/src/compact_heightfield.rs
@@ -6,7 +6,7 @@
 
 use glam::Vec3;
 
-use super::heightfield::Heightfield;
+use super::heightfield::{Heightfield, SPAN_NULL};
 use super::watershed;
 use crate::error::BuildError;
 
@@ -347,14 +347,16 @@ impl CompactHeightfield {
 
         // Count walkable spans only (matching C++)
         let mut span_count = 0;
-        for column in heightfield.spans.values() {
-            let mut current = column.clone();
-            while let Some(span_rc) = current {
-                let span = span_rc.borrow();
-                if span.area != 0 {
-                    span_count += 1;
+        for z in 0..height {
+            for x in 0..width {
+                let mut si = heightfield.column_first_span(x, z);
+                while si != SPAN_NULL {
+                    let s = heightfield.span(si);
+                    if s.area != 0 {
+                        span_count += 1;
+                    }
+                    si = s.next;
                 }
-                current = span.next.clone();
             }
         }
 
@@ -370,32 +372,27 @@ impl CompactHeightfield {
 
         for z in 0..height {
             for x in 0..width {
-                let column = heightfield
-                    .spans
-                    .get(&(x, z))
-                    .ok_or_else(|| BuildError::MissingColumn { x, z })?;
+                let first_si = heightfield.column_first_span(x, z);
 
                 // If the column has no spans, add an empty cell
-                if column.is_none() {
+                if first_si == SPAN_NULL {
                     cells.push(CompactCell::new(None, 0));
                     continue;
                 }
 
                 // Count walkable spans in this cell
                 let mut walkable_count = 0;
-                let mut current = column.clone();
-                while let Some(span_rc) = current {
-                    let span = span_rc.borrow();
-                    if span.area != 0 {
+                let mut si = first_si;
+                while si != SPAN_NULL {
+                    let s = heightfield.span(si);
+                    if s.area != 0 {
                         walkable_count += 1;
                     }
-                    current = span.next.clone();
+                    si = s.next;
                 }
 
                 if walkable_count == 0 {
                     cells.push(CompactCell::new(None, 0));
-                    current = column.clone();
-                    // Still need to advance past this column
                     continue;
                 }
 
@@ -403,39 +400,39 @@ impl CompactHeightfield {
                 cells.push(CompactCell::new(Some(spans.len()), walkable_count));
 
                 // Add only walkable spans (matching C++ rcBuildCompactHeightfield)
-                current = column.clone();
-                while let Some(span_rc) = current {
-                    let span = span_rc.borrow();
+                si = first_si;
+                while si != SPAN_NULL {
+                    let s = heightfield.span(si);
 
-                    if span.area != 0 {
+                    if s.area != 0 {
                         // C++ convention: y = smax (top of solid = walkable surface)
-                        let bot = span.max as i32;
+                        let bot = s.max as i32;
                         // Air gap: from top of this solid to bottom of next solid above
-                        let top = if let Some(ref next) = span.next {
-                            next.borrow().min as i32
+                        let top = if s.next != SPAN_NULL {
+                            heightfield.span(s.next).min as i32
                         } else {
                             MAX_HEIGHT
                         };
                         let air_height = (top - bot).clamp(0, 255);
 
                         spans.push(CompactSpan {
-                            min: span.min,
-                            max: span.max,
-                            area: span.area,
+                            min: s.min,
+                            max: s.max,
+                            area: s.area,
                             reg: 0,
                             first_connection: None,
                             y: bot,
                             h: air_height as u8,
                             con: [63; 4], // RC_NOT_CONNECTED
                         });
-                        areas.push(span.area);
+                        areas.push(s.area);
 
                         // Track max height
-                        max_height = max_height.max(span.max as u16);
+                        max_height = max_height.max(s.max as u16);
                         walkable_span_count += 1;
                     }
 
-                    current = span.next.clone();
+                    si = s.next;
                 }
             }
         }

--- a/crates/recast/src/convex_volume.rs
+++ b/crates/recast/src/convex_volume.rs
@@ -6,7 +6,6 @@
 
 use crate::error::BuildError;
 use glam::Vec3;
-use std::rc::Rc;
 
 use crate::error::ConvexVolumeError;
 
@@ -412,23 +411,18 @@ impl ConvexVolumeSet {
                 let world_z = origin.z + (z as f32 + 0.5) * cell_size;
 
                 // Get the span column for this cell
-                if let Some(Some(span_ref)) = heightfield.spans.get(&(x, z)) {
-                    // Process each span in the column
-                    let mut current_span = Some(Rc::clone(span_ref));
+                let mut si = heightfield.column_first_span(x, z);
+                while si != super::heightfield::SPAN_NULL {
+                    let span = &mut heightfield.spans[si as usize];
 
-                    while let Some(span_rc) = current_span {
-                        let mut span = span_rc.borrow_mut();
+                    // Calculate world height of span top
+                    let world_y = origin.y + span.max as f32 * cell_height;
+                    let point = Vec3::new(world_x, world_y, world_z);
 
-                        // Calculate world height of span top
-                        let world_y = origin.y + span.max as f32 * cell_height;
-                        let point = Vec3::new(world_x, world_y, world_z);
+                    // Apply area from convex volumes
+                    span.area = self.get_area_at_point(point, span.area);
 
-                        // Apply area from convex volumes
-                        span.area = self.get_area_at_point(point, span.area);
-
-                        // Move to next span
-                        current_span = span.next.as_ref().map(Rc::clone);
-                    }
+                    si = span.next;
                 }
             }
         }

--- a/crates/recast/src/heightfield.rs
+++ b/crates/recast/src/heightfield.rs
@@ -2,13 +2,23 @@
 //!
 //! The heightfield is the first data structure in the Recast pipeline.
 //! It's a 2D grid of height spans that represents a voxelized 3D environment.
+//!
+//! Spans are stored in a flat arena (`Vec<SpanEntry>`) indexed by `SpanIndex`.
+//! Each grid cell has a `columns` entry pointing to the first span in that
+//! column (or `SPAN_NULL` if empty). This replaces the previous
+//! `HashMap<(i32,i32), Option<Rc<RefCell<Span>>>>` for O(1) hashing-free
+//! lookups and cache-friendly iteration.
 
 use glam::Vec3;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::collections::HashSet;
 
 use crate::error::BuildError;
+
+/// Index into the span arena. `SPAN_NULL` means no span.
+pub type SpanIndex = u32;
+
+/// Sentinel value indicating "no span" (analogous to a null pointer).
+pub const SPAN_NULL: SpanIndex = u32::MAX;
 
 /// Represents cell bounds in XZ plane
 struct CellBounds {
@@ -18,42 +28,45 @@ struct CellBounds {
     max_z: f32,
 }
 
-/// A span in the heightfield, representing a vertical segment of space
-#[derive(Debug, Clone)]
-pub struct Span {
+/// A span in the heightfield, representing a vertical segment of space.
+///
+/// Stored in the `Heightfield`'s arena. Linked via `next` indices.
+#[derive(Debug, Clone, Copy)]
+pub struct SpanEntry {
     /// The minimum height of the span
     pub min: i16,
     /// The maximum height of the span
     pub max: i16,
     /// Area ID (0 = not walkable)
     pub area: u8,
-    /// Next span in the column, or None if this is the last span
-    pub next: Option<Rc<RefCell<Span>>>,
+    /// Next span in the column, or `SPAN_NULL` if this is the last span
+    pub next: SpanIndex,
 }
 
-impl Span {
-    /// Creates a new span
-    pub fn new(min: i16, max: i16, area: u8) -> Self {
-        Self {
-            min,
-            max,
-            area,
-            next: None,
-        }
-    }
+/// Iterator over spans in a single column.
+pub struct ColumnSpanIter<'a> {
+    arena: &'a [SpanEntry],
+    current: SpanIndex,
+}
 
-    /// Creates a new span with a next span
-    pub fn with_next(min: i16, max: i16, area: u8, next: Rc<RefCell<Span>>) -> Self {
-        Self {
-            min,
-            max,
-            area,
-            next: Some(next),
+impl<'a> Iterator for ColumnSpanIter<'a> {
+    type Item = (SpanIndex, &'a SpanEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == SPAN_NULL {
+            return None;
         }
+        let idx = self.current;
+        let entry = &self.arena[idx as usize];
+        self.current = entry.next;
+        Some((idx, entry))
     }
 }
 
-/// Heightfield structure holding a grid of span columns
+/// Heightfield structure holding a grid of span columns.
+///
+/// Uses a flat `columns` vec indexed by `x + z * width` and an arena-allocated
+/// span storage for O(1) lookups without hashing.
 #[derive(Debug)]
 pub struct Heightfield {
     /// Width of the heightfield along the x-axis
@@ -71,22 +84,22 @@ pub struct Heightfield {
     /// Cell height (vertical resolution)
     pub(crate) ch: f32,
 
-    /// Heightfield grid of span columns
-    pub(crate) spans: HashMap<(i32, i32), Option<Rc<RefCell<Span>>>>,
+    /// One entry per grid cell (width * height). Value is the index of the
+    /// first span in that column, or `SPAN_NULL` if the column is empty.
+    pub(crate) columns: Vec<SpanIndex>,
+
+    /// Arena of all spans. Grows as spans are added. Freed spans are recycled
+    /// via `free_list`.
+    pub(crate) spans: Vec<SpanEntry>,
+
+    /// Head of the freelist for recycled span slots.
+    free_list: SpanIndex,
 }
 
 impl Heightfield {
     /// Creates a new empty heightfield
     pub fn new(width: i32, height: i32, bmin: Vec3, bmax: Vec3, cs: f32, ch: f32) -> Self {
-        let mut spans = HashMap::new();
-
-        // Initialize all cells with None
-        for z in 0..height {
-            for x in 0..width {
-                spans.insert((x, z), None);
-            }
-        }
-
+        let num_cells = (width * height) as usize;
         Self {
             width,
             height,
@@ -94,9 +107,43 @@ impl Heightfield {
             bmax,
             cs,
             ch,
-            spans,
+            columns: vec![SPAN_NULL; num_cells],
+            spans: Vec::new(),
+            free_list: SPAN_NULL,
         }
     }
+
+    // ── Column index helpers ──────────────────────────────────────────
+
+    /// Converts (x, z) to the flat column index.
+    #[inline]
+    fn col_index(&self, x: i32, z: i32) -> usize {
+        (x + z * self.width) as usize
+    }
+
+    // ── Arena allocation ──────────────────────────────────────────────
+
+    /// Allocates a span in the arena (reusing a freelist slot if available).
+    pub(crate) fn alloc_span(&mut self, entry: SpanEntry) -> SpanIndex {
+        if self.free_list != SPAN_NULL {
+            let idx = self.free_list;
+            self.free_list = self.spans[idx as usize].next;
+            self.spans[idx as usize] = entry;
+            idx
+        } else {
+            let idx = self.spans.len() as SpanIndex;
+            self.spans.push(entry);
+            idx
+        }
+    }
+
+    /// Returns a span slot to the freelist for reuse.
+    pub(crate) fn free_span(&mut self, idx: SpanIndex) {
+        self.spans[idx as usize].next = self.free_list;
+        self.free_list = idx;
+    }
+
+    // ── Public accessors ──────────────────────────────────────────────
 
     /// Returns the width of the heightfield along the x-axis.
     pub fn width(&self) -> i32 {
@@ -128,10 +175,43 @@ impl Heightfield {
         self.ch
     }
 
-    /// Returns a reference to the span columns.
-    pub fn spans(&self) -> &HashMap<(i32, i32), Option<Rc<RefCell<Span>>>> {
+    /// Gets the first span index for column (x, z), or `SPAN_NULL` if empty.
+    #[inline]
+    pub fn column_first_span(&self, x: i32, z: i32) -> SpanIndex {
+        self.columns[self.col_index(x, z)]
+    }
+
+    /// Gets a span by index.
+    #[inline]
+    pub fn span(&self, index: SpanIndex) -> &SpanEntry {
+        &self.spans[index as usize]
+    }
+
+    /// Gets a mutable reference to a span by index.
+    #[inline]
+    pub fn span_mut(&mut self, index: SpanIndex) -> &mut SpanEntry {
+        &mut self.spans[index as usize]
+    }
+
+    /// Iterates all spans in a column.
+    pub fn column_spans(&self, x: i32, z: i32) -> ColumnSpanIter<'_> {
+        ColumnSpanIter {
+            arena: &self.spans,
+            current: self.columns[self.col_index(x, z)],
+        }
+    }
+
+    /// Access the full columns slice (for bulk iteration).
+    pub fn columns(&self) -> &[SpanIndex] {
+        &self.columns
+    }
+
+    /// Access the full spans arena (for bulk iteration).
+    pub fn spans_arena(&self) -> &[SpanEntry] {
         &self.spans
     }
+
+    // ── Span insertion ────────────────────────────────────────────────
 
     /// Add a span to the heightfield
     pub fn add_span(
@@ -153,108 +233,74 @@ impl Heightfield {
             });
         }
 
-        let new_span = Rc::new(RefCell::new(Span::new(min, max, area)));
+        let col_idx = self.col_index(x, z);
+        let new_idx = self.alloc_span(SpanEntry {
+            min,
+            max,
+            area,
+            next: SPAN_NULL,
+        });
 
-        match self.spans.get_mut(&(x, z)) {
-            Some(cell) => {
-                match cell {
-                    None => {
-                        // First span in this column
-                        *cell = Some(new_span);
-                    }
-                    Some(first_span) => {
-                        // Insert the span in the column, maintaining height order
-                        Self::insert_span(first_span.clone(), new_span)?;
-                    }
-                }
-            }
-            None => {
-                return Err(BuildError::CellNotFound { x, y: z });
-            }
+        let first = self.columns[col_idx];
+        if first == SPAN_NULL {
+            self.columns[col_idx] = new_idx;
+            return Ok(());
         }
 
-        Ok(())
-    }
+        // Walk the column to find insertion point (sorted by min height)
+        let mut prev = SPAN_NULL;
+        let mut cur = first;
 
-    /// Insert a span into a column, maintaining height order and merging overlapping spans
-    fn insert_span(
-        first_span: Rc<RefCell<Span>>,
-        new_span: Rc<RefCell<Span>>,
-    ) -> Result<(), BuildError> {
-        let mut prev: Option<Rc<RefCell<Span>>> = None;
-        let mut curr = first_span;
-        let (new_min, new_max, new_area) = {
-            let ns = new_span.borrow();
-            (ns.min, ns.max, ns.area)
-        };
-
-        // Find the insertion point
-        loop {
-            let (curr_min, curr_max, curr_area) = {
-                let cs = curr.borrow();
-                (cs.min, cs.max, cs.area)
-            };
+        while cur != SPAN_NULL {
+            let cur_span = self.spans[cur as usize];
 
             // Check for overlap with same area - merge if so
-            if curr_area == new_area && curr_max >= new_min && new_max >= curr_min {
-                // Merge overlapping spans
-                let merged_min = curr_min.min(new_min);
-                let merged_max = curr_max.max(new_max);
+            if cur_span.area == area && cur_span.max >= min && max >= cur_span.min {
+                let merged_min = cur_span.min.min(min);
+                let merged_max = cur_span.max.max(max);
+                self.spans[cur as usize].min = merged_min;
+                self.spans[cur as usize].max = merged_max;
 
-                // Update current span with merged values
-                {
-                    let mut cs = curr.borrow_mut();
-                    cs.min = merged_min;
-                    cs.max = merged_max;
-                }
+                // Free the new span since we merged into cur
+                self.free_span(new_idx);
 
                 // Check if we can merge with the next span too
-                let next_opt = curr.borrow().next.clone();
-                if let Some(next) = next_opt {
-                    let (next_min, next_max, next_area) = {
-                        let ns = next.borrow();
-                        (ns.min, ns.max, ns.area)
-                    };
-
-                    if next_area == new_area && merged_max >= next_min {
-                        // Merge with next span too
-                        let final_max = merged_max.max(next_max);
-                        let next_next = next.borrow().next.clone();
-
-                        let mut cs = curr.borrow_mut();
-                        cs.max = final_max;
-                        cs.next = next_next;
+                let next = self.spans[cur as usize].next;
+                if next != SPAN_NULL {
+                    let next_span = self.spans[next as usize];
+                    if next_span.area == area && merged_max >= next_span.min {
+                        let final_max = merged_max.max(next_span.max);
+                        let next_next = next_span.next;
+                        self.spans[cur as usize].max = final_max;
+                        self.spans[cur as usize].next = next_next;
+                        self.free_span(next);
                     }
                 }
 
                 return Ok(());
             }
 
-            // If new span is below current span
-            if new_max < curr_min {
-                // Insert new span before current span
-                if let Some(prev_span) = prev {
-                    prev_span.borrow_mut().next = Some(new_span.clone());
-                    new_span.borrow_mut().next = Some(curr);
+            // If new span is below current span, insert before
+            if max < cur_span.min {
+                self.spans[new_idx as usize].next = cur;
+                if prev == SPAN_NULL {
+                    self.columns[col_idx] = new_idx;
                 } else {
-                    // This is the first span, need to swap
-                    let curr_clone = curr.borrow().clone();
-                    *curr.borrow_mut() = new_span.borrow().clone();
-                    curr.borrow_mut().next = Some(Rc::new(RefCell::new(curr_clone)));
+                    self.spans[prev as usize].next = new_idx;
                 }
-                break;
+                return Ok(());
             }
 
-            // If there's no next span, add new span at the end
-            let next_opt = curr.borrow().next.clone();
-            if let Some(next) = next_opt {
-                // Move to next span
-                prev = Some(curr);
-                curr = next;
-            } else {
-                curr.borrow_mut().next = Some(new_span);
-                break;
-            }
+            prev = cur;
+            cur = cur_span.next;
+        }
+
+        // Add at end
+        self.spans[new_idx as usize].next = SPAN_NULL;
+        if prev != SPAN_NULL {
+            self.spans[prev as usize].next = new_idx;
+        } else {
+            self.columns[col_idx] = new_idx;
         }
 
         Ok(())
@@ -265,15 +311,9 @@ impl Heightfield {
         let mut min_height = i16::MAX;
         let mut max_height = i16::MIN;
 
-        for column in self.spans.values() {
-            let mut current = column.clone();
-
-            while let Some(span_rc) = current {
-                let span = span_rc.borrow();
-                min_height = min_height.min(span.min);
-                max_height = max_height.max(span.max);
-                current = span.next.clone();
-            }
+        for &entry in &self.spans {
+            min_height = min_height.min(entry.min);
+            max_height = max_height.max(entry.max);
         }
 
         (min_height, max_height)
@@ -285,325 +325,218 @@ impl Heightfield {
         walkable_height: i16,
         walkable_climb: i16,
     ) -> Result<(), BuildError> {
-        // Process each column
-        for ((_x, _z), column) in self.spans.iter_mut() {
-            if let Some(first_span) = column {
-                let mut current_span = Some(first_span.clone());
-
-                while let Some(span_rc) = current_span {
-                    let mut span = span_rc.borrow_mut();
-
-                    // Check if this span is walkable
+        for z in 0..self.height {
+            for x in 0..self.width {
+                let mut si = self.columns[self.col_index(x, z)];
+                while si != SPAN_NULL {
+                    let span = self.spans[si as usize];
                     let span_height = span.max - span.min;
-                    let is_walkable = span_height >= walkable_height;
 
-                    // Check if the climb to the next span is walkable
-                    let should_mark_unwalkable = if let Some(next_span_rc) = &span.next {
-                        let next_span = next_span_rc.borrow();
-                        let climb = next_span.min as i32 - span.max as i32;
-                        climb > walkable_climb as i32
-                    } else {
-                        false
-                    };
-
-                    if should_mark_unwalkable {
-                        span.area = 0;
+                    if span_height < walkable_height {
+                        self.spans[si as usize].area = 0;
                     }
 
-                    // If the span is not walkable, mark it
-                    if !is_walkable {
-                        span.area = 0;
+                    if span.next != SPAN_NULL {
+                        let next = self.spans[span.next as usize];
+                        let climb = next.min as i32 - span.max as i32;
+                        if climb > walkable_climb as i32 {
+                            self.spans[si as usize].area = 0;
+                        }
                     }
 
-                    // Move to next span
-                    current_span = span.next.clone();
+                    si = span.next;
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Filters low hanging walkable obstacles that the agent can step over
-    /// This implements the C++ rcFilterLowHangingWalkableObstacles algorithm
+    /// Filters low hanging walkable obstacles that the agent can step over.
+    /// Implements the C++ rcFilterLowHangingWalkableObstacles algorithm.
     pub fn filter_low_hanging_walkable_obstacles(
         &mut self,
         walkable_climb: i16,
     ) -> Result<(), BuildError> {
-        let x_size = self.width;
-        let z_size = self.height;
+        for z in 0..self.height {
+            for x in 0..self.width {
+                let mut si = self.columns[self.col_index(x, z)];
+                let mut previous_walkable = false;
+                let mut previous_area = 0u8;
+                let mut previous_max = 0i16;
 
-        for z in 0..z_size {
-            for x in 0..x_size {
-                if let Some(Some(first_span)) = self.spans.get(&(x, z)) {
-                    let mut previous_span: Option<Rc<RefCell<Span>>> = None;
-                    let mut previous_was_walkable = false;
-                    let mut previous_area_id = 0u8;
+                while si != SPAN_NULL {
+                    let span = self.spans[si as usize];
+                    let walkable = span.area != 0;
 
-                    let mut current = Some(first_span.clone());
-                    while let Some(span_rc) = current {
-                        let walkable = span_rc.borrow().area != 0; // RC_NULL_AREA is 0
-
-                        // If current span is not walkable, but there is walkable span just below it
-                        // and the height difference is small enough for the agent to walk over,
-                        // mark the current span as walkable too.
-                        if !walkable && previous_was_walkable {
-                            if let Some(prev_span) = &previous_span {
-                                let prev_max = prev_span.borrow().max;
-                                let curr_max = span_rc.borrow().max;
-
-                                if (curr_max as i32 - prev_max as i32) <= walkable_climb as i32 {
-                                    span_rc.borrow_mut().area = previous_area_id;
-                                }
-                            }
+                    if !walkable && previous_walkable {
+                        if (span.max as i32 - previous_max as i32) <= walkable_climb as i32 {
+                            self.spans[si as usize].area = previous_area;
                         }
-
-                        // Copy the original walkable value regardless of whether we changed it.
-                        // This prevents multiple consecutive non-walkable spans from being erroneously marked as walkable.
-                        previous_was_walkable = walkable;
-                        previous_area_id = span_rc.borrow().area;
-                        previous_span = Some(span_rc.clone());
-
-                        current = span_rc.borrow().next.clone();
                     }
+
+                    previous_walkable = walkable;
+                    previous_area = self.spans[si as usize].area;
+                    previous_max = span.max;
+
+                    si = span.next;
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Filters ledge spans - marks spans that are adjacent to ledges as unwalkable
-    /// This implements the C++ rcFilterLedgeSpans algorithm
+    /// Filters ledge spans - marks spans adjacent to ledges as unwalkable.
+    /// Implements the C++ rcFilterLedgeSpans algorithm.
     pub fn filter_ledge_spans(
         &mut self,
         walkable_height: i16,
         walkable_climb: i16,
     ) -> Result<(), BuildError> {
         const MAX_HEIGHTFIELD_HEIGHT: i32 = 0xffff;
-
-        let x_size = self.width;
-        let z_size = self.height;
-
-        // Direction offsets for 4-directional neighbors (N, E, S, W)
         let dir_offsets = [(0, -1), (1, 0), (0, 1), (-1, 0)];
 
-        // Mark spans that are adjacent to a ledge as unwalkable
-        for z in 0..z_size {
-            for x in 0..x_size {
-                if let Some(Some(first_span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(first_span.clone());
+        for z in 0..self.height {
+            for x in 0..self.width {
+                let mut si = self.columns[self.col_index(x, z)];
 
-                    while let Some(span_rc) = current {
-                        let span = span_rc.borrow();
+                while si != SPAN_NULL {
+                    let span = self.spans[si as usize];
 
-                        // Skip non-walkable spans
-                        if span.area == 0 {
-                            current = span.next.clone();
-                            continue;
+                    if span.area == 0 {
+                        si = span.next;
+                        continue;
+                    }
+
+                    let floor = span.max as i32;
+                    let ceiling = if span.next != SPAN_NULL {
+                        self.spans[span.next as usize].min as i32
+                    } else {
+                        MAX_HEIGHTFIELD_HEIGHT
+                    };
+
+                    let mut lowest_neighbor_floor_diff = MAX_HEIGHTFIELD_HEIGHT;
+                    let mut lowest_traversable_floor = span.max as i32;
+                    let mut highest_traversable_floor = span.max as i32;
+                    let mut is_ledge = false;
+
+                    for &(dx, dz) in &dir_offsets {
+                        let nx = x + dx;
+                        let nz = z + dz;
+
+                        if nx < 0 || nz < 0 || nx >= self.width || nz >= self.height {
+                            lowest_neighbor_floor_diff = -walkable_climb as i32 - 1;
+                            is_ledge = true;
+                            break;
                         }
 
-                        let floor = span.max as i32;
-                        let ceiling = if let Some(ref next_span) = span.next {
-                            next_span.borrow().min as i32
+                        let mut nsi = self.columns[self.col_index(nx, nz)];
+
+                        let mut neighbor_ceiling = if nsi != SPAN_NULL {
+                            self.spans[nsi as usize].min as i32
                         } else {
                             MAX_HEIGHTFIELD_HEIGHT
                         };
 
-                        // The difference between this walkable area and the lowest neighbor walkable area
-                        let mut lowest_neighbor_floor_difference = MAX_HEIGHTFIELD_HEIGHT;
+                        if (ceiling.min(neighbor_ceiling) - floor) >= walkable_height as i32 {
+                            lowest_neighbor_floor_diff = -walkable_climb as i32 - 1;
+                            is_ledge = true;
+                            break;
+                        }
 
-                        // Min and max height of accessible neighbours
-                        let mut lowest_traversable_neighbor_floor = span.max as i32;
-                        let mut highest_traversable_neighbor_floor = span.max as i32;
-
-                        // Check all 4 directions
-                        let mut is_ledge = false;
-                        for &(dx, dz) in &dir_offsets {
-                            let neighbor_x = x + dx;
-                            let neighbor_z = z + dz;
-
-                            // Skip neighbours which are out of bounds
-                            if neighbor_x < 0
-                                || neighbor_z < 0
-                                || neighbor_x >= x_size
-                                || neighbor_z >= z_size
-                            {
-                                lowest_neighbor_floor_difference = -walkable_climb as i32 - 1;
-                                is_ledge = true;
-                                break;
-                            }
-
-                            if let Some(Some(neighbor_first_span)) =
-                                self.spans.get(&(neighbor_x, neighbor_z))
-                            {
-                                let mut neighbor_span_opt = Some(neighbor_first_span.clone());
-
-                                // The most we can step down to the neighbor is the walkableClimb distance
-                                let mut neighbor_ceiling =
-                                    if let Some(ref first_neighbor) = neighbor_span_opt {
-                                        first_neighbor.borrow().min as i32
-                                    } else {
-                                        MAX_HEIGHTFIELD_HEIGHT
-                                    };
-
-                                // Skip neighbour if the gap between the spans is too small
-                                if (ceiling.min(neighbor_ceiling) - floor) >= walkable_height as i32
-                                {
-                                    lowest_neighbor_floor_difference = -walkable_climb as i32 - 1;
-                                    is_ledge = true;
-                                    break;
-                                }
-
-                                // For each span in the neighboring column
-                                while let Some(neighbor_span_rc) = neighbor_span_opt {
-                                    let neighbor_span = neighbor_span_rc.borrow();
-                                    let neighbor_floor = neighbor_span.max as i32;
-                                    neighbor_ceiling =
-                                        if let Some(ref next_neighbor) = neighbor_span.next {
-                                            next_neighbor.borrow().min as i32
-                                        } else {
-                                            MAX_HEIGHTFIELD_HEIGHT
-                                        };
-
-                                    // Only consider neighboring areas that have enough overlap to be potentially traversable
-                                    if (ceiling.min(neighbor_ceiling) - floor.max(neighbor_floor))
-                                        < walkable_height as i32
-                                    {
-                                        // No space to traverse between them
-                                        neighbor_span_opt = neighbor_span.next.clone();
-                                        continue;
-                                    }
-
-                                    let neighbor_floor_difference = neighbor_floor - floor;
-                                    lowest_neighbor_floor_difference =
-                                        lowest_neighbor_floor_difference
-                                            .min(neighbor_floor_difference);
-
-                                    // Find min/max accessible neighbor height
-                                    // Only consider neighbors that are at most walkableClimb away
-                                    if neighbor_floor_difference.abs() <= walkable_climb as i32 {
-                                        // There is space to move to the neighbor cell and the slope isn't too much
-                                        lowest_traversable_neighbor_floor =
-                                            lowest_traversable_neighbor_floor.min(neighbor_floor);
-                                        highest_traversable_neighbor_floor =
-                                            highest_traversable_neighbor_floor.max(neighbor_floor);
-                                    } else if neighbor_floor_difference < -walkable_climb as i32 {
-                                        // We already know this will be considered a ledge span so we can early-out
-                                        break;
-                                    }
-
-                                    neighbor_span_opt = neighbor_span.next.clone();
-                                }
+                        while nsi != SPAN_NULL {
+                            let ns = self.spans[nsi as usize];
+                            let neighbor_floor = ns.max as i32;
+                            neighbor_ceiling = if ns.next != SPAN_NULL {
+                                self.spans[ns.next as usize].min as i32
                             } else {
-                                // No neighbor span column - treat as ledge
-                                lowest_neighbor_floor_difference = -walkable_climb as i32 - 1;
-                                is_ledge = true;
+                                MAX_HEIGHTFIELD_HEIGHT
+                            };
+
+                            if (ceiling.min(neighbor_ceiling) - floor.max(neighbor_floor))
+                                < walkable_height as i32
+                            {
+                                nsi = ns.next;
+                                continue;
+                            }
+
+                            let neighbor_floor_diff = neighbor_floor - floor;
+                            lowest_neighbor_floor_diff =
+                                lowest_neighbor_floor_diff.min(neighbor_floor_diff);
+
+                            if neighbor_floor_diff.abs() <= walkable_climb as i32 {
+                                lowest_traversable_floor =
+                                    lowest_traversable_floor.min(neighbor_floor);
+                                highest_traversable_floor =
+                                    highest_traversable_floor.max(neighbor_floor);
+                            } else if neighbor_floor_diff < -walkable_climb as i32 {
                                 break;
                             }
-                        }
 
-                        if is_ledge {
-                            // Mark as unwalkable due to being near boundary or having insufficient clearance
-                            drop(span); // Release borrow before modifying
-                            span_rc.borrow_mut().area = 0;
-                        } else {
-                            // Check ledge conditions
-                            if lowest_neighbor_floor_difference < -walkable_climb as i32 {
-                                // The current span is close to a ledge
-                                drop(span); // Release borrow before modifying
-                                span_rc.borrow_mut().area = 0;
-                            } else if (highest_traversable_neighbor_floor
-                                - lowest_traversable_neighbor_floor)
-                                > walkable_climb as i32
-                            {
-                                // If the difference between all neighbor floors is too large, this is a steep slope
-                                drop(span); // Release borrow before modifying
-                                span_rc.borrow_mut().area = 0;
-                            }
+                            nsi = ns.next;
                         }
-
-                        current = if let Ok(span_ref) = span_rc.try_borrow() {
-                            span_ref.next.clone()
-                        } else {
-                            // If we can't borrow (because we modified it above), get next from the modified span
-                            span_rc.borrow().next.clone()
-                        };
                     }
+
+                    if is_ledge
+                        || lowest_neighbor_floor_diff < -walkable_climb as i32
+                        || (highest_traversable_floor - lowest_traversable_floor)
+                            > walkable_climb as i32
+                    {
+                        self.spans[si as usize].area = 0;
+                    }
+
+                    si = span.next;
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Filters walkable spans that have insufficient clearance above them
-    /// This implements the C++ rcFilterWalkableLowHeightSpans algorithm
+    /// Filters walkable spans that have insufficient clearance above them.
+    /// Implements the C++ rcFilterWalkableLowHeightSpans algorithm.
     pub fn filter_walkable_low_height_spans(
         &mut self,
         walkable_height: i16,
     ) -> Result<(), BuildError> {
         const MAX_HEIGHTFIELD_HEIGHT: i32 = 0xffff;
 
-        let x_size = self.width;
-        let z_size = self.height;
+        for z in 0..self.height {
+            for x in 0..self.width {
+                let mut si = self.columns[self.col_index(x, z)];
 
-        // Remove walkable flag from spans which do not have enough
-        // space above them for the agent to stand there.
-        for z in 0..z_size {
-            for x in 0..x_size {
-                if let Some(Some(first_span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(first_span.clone());
+                while si != SPAN_NULL {
+                    let span = self.spans[si as usize];
+                    let floor = span.max as i32;
+                    let ceiling = if span.next != SPAN_NULL {
+                        self.spans[span.next as usize].min as i32
+                    } else {
+                        MAX_HEIGHTFIELD_HEIGHT
+                    };
 
-                    while let Some(span_rc) = current {
-                        let span = span_rc.borrow();
-                        let floor = span.max as i32;
-                        let ceiling = if let Some(ref next_span) = span.next {
-                            next_span.borrow().min as i32
-                        } else {
-                            MAX_HEIGHTFIELD_HEIGHT
-                        };
-
-                        if (ceiling - floor) < walkable_height as i32 {
-                            drop(span); // Release borrow before modifying
-                            span_rc.borrow_mut().area = 0; // RC_NULL_AREA
-                        }
-
-                        current = if let Ok(span_ref) = span_rc.try_borrow() {
-                            span_ref.next.clone()
-                        } else {
-                            // If we can't borrow (because we modified it above), get next from the modified span
-                            span_rc.borrow().next.clone()
-                        };
+                    if (ceiling - floor) < walkable_height as i32 {
+                        self.spans[si as usize].area = 0;
                     }
+
+                    si = span.next;
                 }
             }
         }
-
         Ok(())
     }
 
     /// Marks border spans (spans at the edge of the heightfield)
     #[allow(dead_code)]
     fn mark_border_spans(&mut self) -> Result<(), BuildError> {
-        // Mark spans on the border of the heightfield
         for z in 0..self.height {
             for x in 0..self.width {
-                // Check if this is a border cell
                 if x == 0 || x == self.width - 1 || z == 0 || z == self.height - 1 {
-                    if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                        let mut current = Some(span.clone());
-
-                        while let Some(span_rc) = current {
-                            // Mark border spans as unwalkable
-                            span_rc.borrow_mut().area = 0;
-                            current = span_rc.borrow().next.clone();
-                        }
+                    let mut si = self.columns[self.col_index(x, z)];
+                    while si != SPAN_NULL {
+                        self.spans[si as usize].area = 0;
+                        si = self.spans[si as usize].next;
                     }
                 }
             }
         }
-
         Ok(())
     }
 
@@ -613,21 +546,17 @@ impl Heightfield {
         let height = self.height;
 
         // Create a copy of area values for reading
-        let mut area_copy = HashMap::new();
+        let mut area_copy = std::collections::HashMap::new();
 
-        // Copy current area values
         for z in 0..height {
             for x in 0..width {
-                if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(span.clone());
-                    let mut span_index = 0;
+                let mut si = self.columns[self.col_index(x, z)];
+                let mut span_index = 0;
 
-                    while let Some(span_rc) = current {
-                        let area = span_rc.borrow().area;
-                        area_copy.insert((x, z, span_index), area);
-                        current = span_rc.borrow().next.clone();
-                        span_index += 1;
-                    }
+                while si != SPAN_NULL {
+                    area_copy.insert((x, z, span_index), self.spans[si as usize].area);
+                    si = self.spans[si as usize].next;
+                    span_index += 1;
                 }
             }
         }
@@ -635,47 +564,37 @@ impl Heightfield {
         // Apply median filter
         for z in 1..height - 1 {
             for x in 1..width - 1 {
-                if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(span.clone());
-                    let mut span_index = 0;
+                let mut si = self.columns[self.col_index(x, z)];
+                let mut span_index = 0;
 
-                    while let Some(span_rc) = current {
-                        let mut neighbor_areas = Vec::new();
+                while si != SPAN_NULL {
+                    let mut neighbor_areas = Vec::new();
 
-                        // Collect areas from 3x3 neighborhood at similar heights
-                        for dz in -1..=1 {
-                            for dx in -1..=1 {
-                                let nx = x + dx;
-                                let nz = z + dz;
-
-                                if let Some(&area) = area_copy.get(&(nx, nz, span_index)) {
-                                    neighbor_areas.push(area);
-                                }
+                    for dz in -1..=1 {
+                        for dx in -1..=1 {
+                            let nx = x + dx;
+                            let nz = z + dz;
+                            if let Some(&area) = area_copy.get(&(nx, nz, span_index)) {
+                                neighbor_areas.push(area);
                             }
                         }
-
-                        // Apply median filter if we have enough neighbors
-                        if neighbor_areas.len() >= 5 {
-                            neighbor_areas.sort();
-                            let median_area = neighbor_areas[neighbor_areas.len() / 2];
-
-                            // Only change if current area is different from median
-                            let current_area = span_rc.borrow().area;
-                            if current_area != median_area {
-                                // Count occurrences of median value
-                                let median_count =
-                                    neighbor_areas.iter().filter(|&&a| a == median_area).count();
-
-                                // Only change if median is dominant (appears in majority)
-                                if median_count > neighbor_areas.len() / 2 {
-                                    span_rc.borrow_mut().area = median_area;
-                                }
-                            }
-                        }
-
-                        current = span_rc.borrow().next.clone();
-                        span_index += 1;
                     }
+
+                    if neighbor_areas.len() >= 5 {
+                        neighbor_areas.sort();
+                        let median_area = neighbor_areas[neighbor_areas.len() / 2];
+                        let current_area = self.spans[si as usize].area;
+                        if current_area != median_area {
+                            let median_count =
+                                neighbor_areas.iter().filter(|&&a| a == median_area).count();
+                            if median_count > neighbor_areas.len() / 2 {
+                                self.spans[si as usize].area = median_area;
+                            }
+                        }
+                    }
+
+                    si = self.spans[si as usize].next;
+                    span_index += 1;
                 }
             }
         }
@@ -697,17 +616,15 @@ impl Heightfield {
 
         for z in 0..height {
             for x in 0..width {
-                if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(span.clone());
-                    let mut span_index = 0;
+                let mut si = self.columns[self.col_index(x, z)];
+                let mut span_index = 0;
 
-                    while let Some(span_rc) = current {
-                        if span_rc.borrow().area == 0 {
-                            non_walkable.insert((x, z, span_index));
-                        }
-                        current = span_rc.borrow().next.clone();
-                        span_index += 1;
+                while si != SPAN_NULL {
+                    if self.spans[si as usize].area == 0 {
+                        non_walkable.insert((x, z, span_index));
                     }
+                    si = self.spans[si as usize].next;
+                    span_index += 1;
                 }
             }
         }
@@ -716,18 +633,15 @@ impl Heightfield {
         let mut to_erode = HashSet::new();
 
         for &(x, z, span_index) in &non_walkable {
-            // Check all cells within radius
             for dz in -radius..=radius {
                 for dx in -radius..=radius {
                     let nx = x + dx;
                     let nz = z + dz;
 
-                    // Skip out of bounds
                     if nx < 0 || nx >= width || nz < 0 || nz >= height {
                         continue;
                     }
 
-                    // Check if within radius (using squared distance to avoid sqrt)
                     let dist_sq = dx * dx + dz * dz;
                     if dist_sq <= radius * radius {
                         to_erode.insert((nx, nz, span_index));
@@ -738,18 +652,16 @@ impl Heightfield {
 
         // Apply erosion
         for (x, z, span_index) in to_erode {
-            if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                let mut current = Some(span.clone());
-                let mut idx = 0;
+            let mut si = self.columns[self.col_index(x, z)];
+            let mut idx = 0;
 
-                while let Some(span_rc) = current {
-                    if idx == span_index {
-                        span_rc.borrow_mut().area = 0;
-                        break;
-                    }
-                    current = span_rc.borrow().next.clone();
-                    idx += 1;
+            while si != SPAN_NULL {
+                if idx == span_index {
+                    self.spans[si as usize].area = 0;
+                    break;
                 }
+                si = self.spans[si as usize].next;
+                idx += 1;
             }
         }
 
@@ -792,7 +704,6 @@ impl Heightfield {
         // Rasterize the triangle using conservative rasterization
         for z in min_z..=max_z {
             for x in min_x..=max_x {
-                // Get cell bounds
                 let bounds = CellBounds {
                     min_x: self.bmin.x + (x as f32) * self.cs,
                     max_x: self.bmin.x + ((x + 1) as f32) * self.cs,
@@ -800,28 +711,19 @@ impl Heightfield {
                     max_z: self.bmin.z + ((z + 1) as f32) * self.cs,
                 };
 
-                // Check if triangle overlaps this cell using a more conservative approach
                 if !self.triangle_overlaps_cell_xz(&verts[0], &verts[1], &verts[2], &bounds) {
                     continue;
                 }
 
-                // Use cell center for height interpolation
                 let pt = Vec3::new(
                     self.bmin.x + (x as f32 + 0.5) * self.cs,
                     0.0,
                     self.bmin.z + (z as f32 + 0.5) * self.cs,
                 );
 
-                // Calculate the height (y) at this point using barycentric coordinates
                 let y = self.interpolate_height(&pt, &verts[0], &verts[1], &verts[2]);
-
-                // Convert to heightfield height (span height)
                 let h = ((y - self.bmin.y) / self.ch) as i16;
-
-                // Add span to the heightfield
-                // Create a span with sufficient height to represent walkable space
-                // The span extends from the surface up by a reasonable amount
-                let span_height = 10; // Default height for walkable spans
+                let span_height = 10;
                 let max_height = h.saturating_add(span_height);
                 self.add_span(x, z, h, max_height, area)?;
             }
@@ -832,7 +734,6 @@ impl Heightfield {
 
     /// Checks if a point is inside a triangle (XZ plane projection)
     fn point_in_triangle_xz(&self, p: &Vec3, a: &Vec3, b: &Vec3, c: &Vec3) -> bool {
-        // Compute vectors
         let v0x = c.x - a.x;
         let v0z = c.z - a.z;
         let v1x = b.x - a.x;
@@ -840,19 +741,16 @@ impl Heightfield {
         let v2x = p.x - a.x;
         let v2z = p.z - a.z;
 
-        // Compute dot products
         let dot00 = v0x * v0x + v0z * v0z;
         let dot01 = v0x * v1x + v0z * v1z;
         let dot02 = v0x * v2x + v0z * v2z;
         let dot11 = v1x * v1x + v1z * v1z;
         let dot12 = v1x * v2x + v1z * v2z;
 
-        // Compute barycentric coordinates
         let inv_denom = 1.0 / (dot00 * dot11 - dot01 * dot01);
         let u = (dot11 * dot02 - dot01 * dot12) * inv_denom;
         let v = (dot00 * dot12 - dot01 * dot02) * inv_denom;
 
-        // Check if point is in triangle
         (u >= 0.0) && (v >= 0.0) && (u + v <= 1.0)
     }
 
@@ -864,7 +762,6 @@ impl Heightfield {
         v2: &Vec3,
         bounds: &CellBounds,
     ) -> bool {
-        // First, check if triangle bounding box overlaps cell
         let tri_min_x = v0.x.min(v1.x).min(v2.x);
         let tri_max_x = v0.x.max(v1.x).max(v2.x);
         let tri_min_z = v0.z.min(v1.z).min(v2.z);
@@ -878,7 +775,6 @@ impl Heightfield {
             return false;
         }
 
-        // Check if any cell corner is inside the triangle
         let corners = [
             Vec3::new(bounds.min_x, 0.0, bounds.min_z),
             Vec3::new(bounds.max_x, 0.0, bounds.min_z),
@@ -892,7 +788,6 @@ impl Heightfield {
             }
         }
 
-        // Check if any triangle vertex is inside the cell
         if v0.x >= bounds.min_x
             && v0.x <= bounds.max_x
             && v0.z >= bounds.min_z
@@ -915,9 +810,6 @@ impl Heightfield {
             return true;
         }
 
-        // Check if any triangle edge intersects the cell
-        // This handles the case where the triangle passes through the cell
-        // but no vertices are inside and no corners are inside the triangle
         if self.edge_intersects_cell_xz(v0, v1, bounds)
             || self.edge_intersects_cell_xz(v1, v2, bounds)
             || self.edge_intersects_cell_xz(v2, v0, bounds)
@@ -925,18 +817,14 @@ impl Heightfield {
             return true;
         }
 
-        // If none of the above conditions are met, there's no overlap
         false
     }
 
     /// Checks if an edge intersects a cell in the XZ plane
     fn edge_intersects_cell_xz(&self, p0: &Vec3, p1: &Vec3, bounds: &CellBounds) -> bool {
-        // Check if edge crosses any of the four cell boundaries
-        // Using parametric line equation: p = p0 + t * (p1 - p0)
         let dx = p1.x - p0.x;
         let dz = p1.z - p0.z;
 
-        // Check intersection with left edge (x = cell_min_x)
         if dx.abs() > f32::EPSILON {
             let t = (bounds.min_x - p0.x) / dx;
             if (0.0..=1.0).contains(&t) {
@@ -947,7 +835,6 @@ impl Heightfield {
             }
         }
 
-        // Check intersection with right edge (x = cell_max_x)
         if dx.abs() > f32::EPSILON {
             let t = (bounds.max_x - p0.x) / dx;
             if (0.0..=1.0).contains(&t) {
@@ -958,7 +845,6 @@ impl Heightfield {
             }
         }
 
-        // Check intersection with bottom edge (z = cell_min_z)
         if dz.abs() > f32::EPSILON {
             let t = (bounds.min_z - p0.z) / dz;
             if (0.0..=1.0).contains(&t) {
@@ -969,7 +855,6 @@ impl Heightfield {
             }
         }
 
-        // Check intersection with top edge (z = cell_max_z)
         if dz.abs() > f32::EPSILON {
             let t = (bounds.max_z - p0.z) / dz;
             if (0.0..=1.0).contains(&t) {
@@ -985,7 +870,6 @@ impl Heightfield {
 
     /// Interpolates the height at a point inside a triangle
     fn interpolate_height(&self, p: &Vec3, a: &Vec3, b: &Vec3, c: &Vec3) -> f32 {
-        // Compute vectors
         let v0x = c.x - a.x;
         let v0z = c.z - a.z;
         let v1x = b.x - a.x;
@@ -993,20 +877,17 @@ impl Heightfield {
         let v2x = p.x - a.x;
         let v2z = p.z - a.z;
 
-        // Compute dot products
         let dot00 = v0x * v0x + v0z * v0z;
         let dot01 = v0x * v1x + v0z * v1z;
         let dot02 = v0x * v2x + v0z * v2z;
         let dot11 = v1x * v1x + v1z * v1z;
         let dot12 = v1x * v2x + v1z * v2z;
 
-        // Compute barycentric coordinates
         let inv_denom = 1.0 / (dot00 * dot11 - dot01 * dot01);
         let u = (dot11 * dot02 - dot01 * dot12) * inv_denom;
         let v = (dot00 * dot12 - dot01 * dot02) * inv_denom;
         let w = 1.0 - u - v;
 
-        // Interpolate height
         a.y * w + b.y * v + c.y * u
     }
 
@@ -1017,42 +898,31 @@ impl Heightfield {
         bmax: &[f32; 3],
         area_id: u8,
     ) -> Result<(), BuildError> {
-        // Convert world coordinates to cell coordinates
         let min_x = ((bmin[0] - self.bmin.x) / self.cs).floor() as i32;
         let min_z = ((bmin[2] - self.bmin.z) / self.cs).floor() as i32;
         let max_x = ((bmax[0] - self.bmin.x) / self.cs).ceil() as i32;
         let max_z = ((bmax[2] - self.bmin.z) / self.cs).ceil() as i32;
 
-        // Clamp to heightfield bounds
         let min_x = min_x.max(0);
         let min_z = min_z.max(0);
         let max_x = max_x.min(self.width - 1);
         let max_z = max_z.min(self.height - 1);
 
-        // Convert Y bounds to span units
         let min_y = ((bmin[1] - self.bmin.y) / self.ch).floor() as i16;
         let max_y = ((bmax[1] - self.bmin.y) / self.ch).ceil() as i16;
 
-        // Mark all spans within the box
         for z in min_z..=max_z {
             for x in min_x..=max_x {
-                if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(span.clone());
-
-                    while let Some(span_rc) = current {
-                        let mut span_ref = span_rc.borrow_mut();
-
-                        // Check if span overlaps with the box in Y
-                        if span_ref.min <= max_y && span_ref.max >= min_y {
-                            span_ref.area = area_id;
-                        }
-
-                        current = span_ref.next.clone();
+                let mut si = self.columns[self.col_index(x, z)];
+                while si != SPAN_NULL {
+                    let span = &mut self.spans[si as usize];
+                    if span.min <= max_y && span.max >= min_y {
+                        span.area = area_id;
                     }
+                    si = span.next;
                 }
             }
         }
-
         Ok(())
     }
 
@@ -1064,55 +934,41 @@ impl Heightfield {
         height: f32,
         area_id: u8,
     ) -> Result<(), BuildError> {
-        // Convert cylinder bounds to cell coordinates
         let min_x = ((pos[0] - radius - self.bmin.x) / self.cs).floor() as i32;
         let min_z = ((pos[2] - radius - self.bmin.z) / self.cs).floor() as i32;
         let max_x = ((pos[0] + radius - self.bmin.x) / self.cs).ceil() as i32;
         let max_z = ((pos[2] + radius - self.bmin.z) / self.cs).ceil() as i32;
 
-        // Clamp to heightfield bounds
         let min_x = min_x.max(0);
         let min_z = min_z.max(0);
         let max_x = max_x.min(self.width - 1);
         let max_z = max_z.min(self.height - 1);
 
-        // Convert Y bounds to span units
         let min_y = ((pos[1] - self.bmin.y) / self.ch).floor() as i16;
         let max_y = ((pos[1] + height - self.bmin.y) / self.ch).ceil() as i16;
 
         let radius_sq = radius * radius;
 
-        // Mark all spans within the cylinder
         for z in min_z..=max_z {
             for x in min_x..=max_x {
-                // Calculate cell center
                 let cell_x = self.bmin.x + (x as f32 + 0.5) * self.cs;
                 let cell_z = self.bmin.z + (z as f32 + 0.5) * self.cs;
-
-                // Check if cell center is within cylinder radius
                 let dx = cell_x - pos[0];
                 let dz = cell_z - pos[2];
                 let dist_sq = dx * dx + dz * dz;
 
                 if dist_sq <= radius_sq {
-                    if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                        let mut current = Some(span.clone());
-
-                        while let Some(span_rc) = current {
-                            let mut span_ref = span_rc.borrow_mut();
-
-                            // Check if span overlaps with the cylinder in Y
-                            if span_ref.min <= max_y && span_ref.max >= min_y {
-                                span_ref.area = area_id;
-                            }
-
-                            current = span_ref.next.clone();
+                    let mut si = self.columns[self.col_index(x, z)];
+                    while si != SPAN_NULL {
+                        let span = &mut self.spans[si as usize];
+                        if span.min <= max_y && span.max >= min_y {
+                            span.area = area_id;
                         }
+                        si = span.next;
                     }
                 }
             }
         }
-
         Ok(())
     }
 
@@ -1129,7 +985,6 @@ impl Heightfield {
             return Err(BuildError::DegeneratePolygon);
         }
 
-        // Find polygon bounds
         let mut poly_min_x = verts[0];
         let mut poly_max_x = verts[0];
         let mut poly_min_z = verts[2];
@@ -1144,56 +999,41 @@ impl Heightfield {
             poly_max_z = poly_max_z.max(z);
         }
 
-        // Convert bounds to cell coordinates
         let min_x = ((poly_min_x - self.bmin.x) / self.cs).floor() as i32;
         let min_z = ((poly_min_z - self.bmin.z) / self.cs).floor() as i32;
         let max_x = ((poly_max_x - self.bmin.x) / self.cs).ceil() as i32;
         let max_z = ((poly_max_z - self.bmin.z) / self.cs).ceil() as i32;
 
-        // Clamp to heightfield bounds
         let min_x = min_x.max(0);
         let min_z = min_z.max(0);
         let max_x = max_x.min(self.width - 1);
         let max_z = max_z.min(self.height - 1);
 
-        // Convert Y bounds to span units
         let span_min_y = ((min_y - self.bmin.y) / self.ch).floor() as i16;
         let span_max_y = ((max_y - self.bmin.y) / self.ch).ceil() as i16;
 
-        // Mark all spans within the polygon
         for z in min_z..=max_z {
             for x in min_x..=max_x {
-                // Calculate cell center
                 let cell_x = self.bmin.x + (x as f32 + 0.5) * self.cs;
                 let cell_z = self.bmin.z + (z as f32 + 0.5) * self.cs;
 
-                // Check if cell center is within polygon using point-in-polygon test
                 if Self::point_in_poly_2d(cell_x, cell_z, verts, nverts) {
-                    if let Some(Some(span)) = self.spans.get(&(x, z)) {
-                        let mut current = Some(span.clone());
-
-                        while let Some(span_rc) = current {
-                            let mut span_ref = span_rc.borrow_mut();
-
-                            // Check if span overlaps with the height range
-                            if span_ref.min <= span_max_y && span_ref.max >= span_min_y {
-                                span_ref.area = area_id;
-                            }
-
-                            current = span_ref.next.clone();
+                    let mut si = self.columns[self.col_index(x, z)];
+                    while si != SPAN_NULL {
+                        let span = &mut self.spans[si as usize];
+                        if span.min <= span_max_y && span.max >= span_min_y {
+                            span.area = area_id;
                         }
+                        si = span.next;
                     }
                 }
             }
         }
-
         Ok(())
     }
 
     /// Tests if a point is inside a 2D convex polygon
     fn point_in_poly_2d(px: f32, pz: f32, verts: &[f32], nverts: usize) -> bool {
-        // Use the cross product method for convex polygons
-        // Point is inside if it's on the same side of all edges
         let mut sign = 0i32;
 
         for i in 0..nverts {
@@ -1204,15 +1044,10 @@ impl Heightfield {
             let v1x = verts[j * 3];
             let v1z = verts[j * 3 + 2];
 
-            // Edge vector
             let edge_x = v1x - v0x;
             let edge_z = v1z - v0z;
-
-            // Vector from vertex to point
             let to_point_x = px - v0x;
             let to_point_z = pz - v0z;
-
-            // Cross product (2D)
             let cross = edge_x * to_point_z - edge_z * to_point_x;
 
             if i == 0 {
@@ -1234,15 +1069,12 @@ impl Heightfield {
 
         for z in 0..self.height {
             for x in 0..self.width {
-                if let Some(Some(span_ref)) = self.spans.get(&(x, z)) {
-                    let mut current = Some(Rc::clone(span_ref));
-                    while let Some(span) = current {
-                        let span_borrow = span.borrow();
-                        if span_borrow.area != 0 {
-                            count += 1;
-                        }
-                        current = span_borrow.next.as_ref().map(Rc::clone);
+                let mut si = self.columns[self.col_index(x, z)];
+                while si != SPAN_NULL {
+                    if self.spans[si as usize].area != 0 {
+                        count += 1;
                     }
+                    si = self.spans[si as usize].next;
                 }
             }
         }
@@ -1269,7 +1101,7 @@ mod tests {
 
         assert_eq!(heightfield.width, width);
         assert_eq!(heightfield.height, height);
-        assert_eq!(heightfield.spans.len(), (width * height) as usize);
+        assert_eq!(heightfield.columns.len(), (width * height) as usize);
     }
 
     #[test]
@@ -1283,7 +1115,6 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add a span
         let x = 5;
         let z = 5;
         let min = 3;
@@ -1293,14 +1124,14 @@ mod tests {
         heightfield.add_span(x, z, min, max, area).unwrap();
 
         // Check that the span was added correctly
-        let span = heightfield.spans.get(&(x, z)).unwrap();
-        assert!(span.is_some());
+        let si = heightfield.column_first_span(x, z);
+        assert_ne!(si, SPAN_NULL);
 
-        let span = span.as_ref().unwrap().borrow();
+        let span = heightfield.span(si);
         assert_eq!(span.min, min);
         assert_eq!(span.max, max);
         assert_eq!(span.area, area);
-        assert!(span.next.is_none());
+        assert_eq!(span.next, SPAN_NULL);
     }
 
     #[test]
@@ -1314,7 +1145,6 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Create a triangle that covers several cells
         let triangle = [
             Vec3::new(2.0, 5.0, 2.0),
             Vec3::new(8.0, 5.0, 2.0),
@@ -1322,27 +1152,16 @@ mod tests {
         ];
 
         let area = 1;
-
         heightfield.rasterize_triangle(&triangle, area).unwrap();
 
-        // Check if the triangle was rasterized correctly
-        // The triangle should cover approximately these cells:
-        // (2,2), (3,2), (4,2), (5,2), (6,2), (7,2), (8,2)
-        // (2,3), (3,3), (4,3), (5,3), (6,3), (7,3), (8,3)
-        // (3,4), (4,4), (5,4), (6,4), (7,4)
-        // (3,5), (4,5), (5,5), (6,5), (7,5)
-        // (4,6), (5,6), (6,6)
-        // (4,7), (5,7), (6,7)
-        // (5,8)
-
         // Check a few specific cells that should be inside the triangle
-        assert!(heightfield.spans.get(&(5, 5)).unwrap().is_some());
-        assert!(heightfield.spans.get(&(2, 2)).unwrap().is_some());
-        assert!(heightfield.spans.get(&(7, 2)).unwrap().is_some()); // Changed from (8,2)
-        assert!(heightfield.spans.get(&(5, 6)).unwrap().is_some()); // Changed from (5,8)
+        assert_ne!(heightfield.column_first_span(5, 5), SPAN_NULL);
+        assert_ne!(heightfield.column_first_span(2, 2), SPAN_NULL);
+        assert_ne!(heightfield.column_first_span(7, 2), SPAN_NULL);
+        assert_ne!(heightfield.column_first_span(5, 6), SPAN_NULL);
 
         // Check a cell outside the triangle
-        assert!(heightfield.spans.get(&(0, 0)).unwrap().is_none());
+        assert_eq!(heightfield.column_first_span(0, 0), SPAN_NULL);
     }
 
     #[test]
@@ -1356,14 +1175,12 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add some spans
         for z in 0..height {
             for x in 0..width {
                 heightfield.add_span(x, z, 0, 10, 1).unwrap();
             }
         }
 
-        // Mark a box area
         let box_min = [2.0, 2.0, 2.0];
         let box_max = [5.0, 8.0, 5.0];
         heightfield.mark_box_area(&box_min, &box_max, 5).unwrap();
@@ -1371,18 +1188,16 @@ mod tests {
         // Check that spans within the box have area 5
         for z in 2..5 {
             for x in 2..5 {
-                if let Some(Some(span)) = heightfield.spans.get(&(x, z)) {
-                    let span_ref = span.borrow();
-                    assert_eq!(span_ref.area, 5);
-                }
+                let si = heightfield.column_first_span(x, z);
+                assert_ne!(si, SPAN_NULL);
+                assert_eq!(heightfield.span(si).area, 5);
             }
         }
 
         // Check that spans outside the box still have area 1
-        if let Some(Some(span)) = heightfield.spans.get(&(0, 0)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 1);
-        }
+        let si = heightfield.column_first_span(0, 0);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 1);
     }
 
     #[test]
@@ -1396,14 +1211,12 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add some spans
         for z in 0..height {
             for x in 0..width {
                 heightfield.add_span(x, z, 0, 10, 1).unwrap();
             }
         }
 
-        // Mark a cylinder area
         let pos = [5.0, 2.0, 5.0];
         let radius = 2.5;
         let cylinder_height = 6.0;
@@ -1412,16 +1225,14 @@ mod tests {
             .unwrap();
 
         // Check center should be marked
-        if let Some(Some(span)) = heightfield.spans.get(&(5, 5)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 6);
-        }
+        let si = heightfield.column_first_span(5, 5);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 6);
 
         // Check corner should not be marked (outside radius)
-        if let Some(Some(span)) = heightfield.spans.get(&(2, 2)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 1);
-        }
+        let si = heightfield.column_first_span(2, 2);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 1);
     }
 
     #[test]
@@ -1435,14 +1246,12 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add some spans
         for z in 0..height {
             for x in 0..width {
                 heightfield.add_span(x, z, 0, 10, 1).unwrap();
             }
         }
 
-        // Define a square polygon
         let verts = vec![
             3.0, 0.0, 3.0, // vertex 0
             7.0, 0.0, 3.0, // vertex 1
@@ -1455,16 +1264,14 @@ mod tests {
             .unwrap();
 
         // Check center should be marked
-        if let Some(Some(span)) = heightfield.spans.get(&(5, 5)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 7);
-        }
+        let si = heightfield.column_first_span(5, 5);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 7);
 
         // Check outside should not be marked
-        if let Some(Some(span)) = heightfield.spans.get(&(1, 1)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 1);
-        }
+        let si = heightfield.column_first_span(1, 1);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 1);
     }
 
     #[test]
@@ -1478,31 +1285,24 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add a walkable span, then a low obstacle, then walkable space above
         heightfield.add_span(2, 2, 0, 5, 1).unwrap(); // ground
-        heightfield.add_span(2, 2, 6, 8, 0).unwrap(); // low obstacle (height 2)
-        heightfield.add_span(2, 2, 9, 15, 1).unwrap(); // walkable space above
+        heightfield.add_span(2, 2, 6, 8, 0).unwrap(); // low obstacle
+        heightfield.add_span(2, 2, 9, 15, 1).unwrap(); // walkable above
 
-        let walkable_climb = 3; // Can climb 3 units
+        let walkable_climb = 3;
         heightfield
             .filter_low_hanging_walkable_obstacles(walkable_climb)
             .unwrap();
 
-        // Check that the low obstacle is now marked as walkable
-        if let Some(Some(span)) = heightfield.spans.get(&(2, 2)) {
-            let mut current = Some(span.clone());
-            let mut count = 0;
-
-            while let Some(span_rc) = current {
-                let area = span_rc.borrow().area;
-                // All spans should now be walkable
-                assert_eq!(area, 1);
-                current = span_rc.borrow().next.clone();
-                count += 1;
-            }
-
-            assert_eq!(count, 3); // Should have 3 spans
+        // Check that all spans are now walkable
+        let mut si = heightfield.column_first_span(2, 2);
+        let mut count = 0;
+        while si != SPAN_NULL {
+            assert_eq!(heightfield.span(si).area, 1);
+            si = heightfield.span(si).next;
+            count += 1;
         }
+        assert_eq!(count, 3);
     }
 
     #[test]
@@ -1516,11 +1316,9 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add walkable spans everywhere (but only ground level)
         for z in 0..height {
             for x in 0..width {
                 if x == 2 && z == 2 {
-                    // Add non-walkable obstacle at center
                     heightfield.add_span(x, z, 0, 5, 0).unwrap();
                 } else {
                     heightfield.add_span(x, z, 0, 5, 1).unwrap();
@@ -1531,20 +1329,18 @@ mod tests {
         let radius = 1;
         heightfield.erode_walkable_area(radius).unwrap();
 
-        // Check erosion results
         for z in 0..height {
             for x in 0..width {
-                if let Some(Some(span)) = heightfield.spans.get(&(x, z)) {
-                    let span_ref = span.borrow();
+                let si = heightfield.column_first_span(x, z);
+                if si != SPAN_NULL {
+                    let span = heightfield.span(si);
                     let dist_sq = (x - 2) * (x - 2) + (z - 2) * (z - 2);
 
                     if dist_sq <= radius * radius {
-                        // Areas within radius 1 of (2,2) should be eroded (non-walkable)
-                        assert_eq!(span_ref.area, 0, "Span at ({}, {}) should be eroded", x, z);
+                        assert_eq!(span.area, 0, "Span at ({}, {}) should be eroded", x, z);
                     } else {
-                        // Areas outside radius should remain walkable
                         assert_eq!(
-                            span_ref.area, 1,
+                            span.area, 1,
                             "Span at ({}, {}) should remain walkable",
                             x, z
                         );
@@ -1565,7 +1361,6 @@ mod tests {
 
         let mut heightfield = Heightfield::new(width, height, bmin, bmax, cs, ch);
 
-        // Add spans with noise (most walkable, one non-walkable in the middle)
         for z in 0..height {
             for x in 0..width {
                 let area = if x == 2 && z == 2 { 0 } else { 1 };
@@ -1575,10 +1370,8 @@ mod tests {
 
         heightfield.median_filter_walkable_area().unwrap();
 
-        // The noise in the center should be filtered out (changed to walkable)
-        if let Some(Some(span)) = heightfield.spans.get(&(2, 2)) {
-            let span_ref = span.borrow();
-            assert_eq!(span_ref.area, 1);
-        }
+        let si = heightfield.column_first_span(2, 2);
+        assert_ne!(si, SPAN_NULL);
+        assert_eq!(heightfield.span(si).area, 1);
     }
 }

--- a/crates/recast/src/heightfield_layers.rs
+++ b/crates/recast/src/heightfield_layers.rs
@@ -736,18 +736,17 @@ impl LayeredHeightfield {
         // Process each column in the heightfield
         for z in 0..heightfield.height {
             for x in 0..heightfield.width {
-                if let Some(Some(first_span)) = heightfield.spans.get(&(x, z)) {
-                    let mut current_span = Some(first_span.clone());
+                {
                     let mut column_spans = Vec::new();
 
                     // Collect all spans in this column
-                    while let Some(span_rc) = current_span {
-                        let span = span_rc.borrow();
-                        if span.area != 0 {
-                            // Only include walkable spans
-                            column_spans.push((span.min, span.max, span.area));
+                    let mut si = heightfield.column_first_span(x, z);
+                    while si != super::heightfield::SPAN_NULL {
+                        let s = heightfield.span(si);
+                        if s.area != 0 {
+                            column_spans.push((s.min, s.max, s.area));
                         }
-                        current_span = span.next.clone();
+                        si = s.next;
                     }
 
                     // Separate spans into layers based on height gaps

--- a/crates/recast/src/lib.rs
+++ b/crates/recast/src/lib.rs
@@ -33,7 +33,7 @@ pub use detail_mesh::{PolyMeshDetail, merge_poly_mesh_details};
 pub use distance_field::{build_layer_regions, build_regions_monotone, build_regions_watershed};
 pub use error::{BuildError, ConfigError, ConvexVolumeError};
 // Region building functions are not exported directly - use CompactHeightfield methods instead
-pub use heightfield::{Heightfield, Span};
+pub use heightfield::{ColumnSpanIter, Heightfield, SPAN_NULL, SpanEntry, SpanIndex};
 pub use heightfield_layers::{HeightfieldLayer, LayerConnection, LayeredHeightfield};
 pub use mesh_merging::{MergeResult, MergeStats, MeshMergeConfig, MeshMerger, copy_poly_mesh};
 pub use polymesh::{MESH_NULL_IDX, PolyMesh};

--- a/crates/recast/src/rasterization.rs
+++ b/crates/recast/src/rasterization.rs
@@ -3,11 +3,9 @@
 //! This module provides functions to rasterize triangles into heightfields,
 //! following the exact C++ implementation from RecastRasterization.cpp.
 
-use super::heightfield::{Heightfield, Span};
+use super::heightfield::{Heightfield, SPAN_NULL, SpanEntry, SpanIndex};
 use crate::error::BuildError;
 use glam::Vec3;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 /// Axis enum for polygon clipping
 #[derive(Debug, Clone, Copy)]
@@ -46,8 +44,8 @@ pub fn add_span(
     )
 }
 
-/// Internal implementation of span addition with merging logic
-/// Matches C++ addSpan static function
+/// Internal implementation of span addition with merging logic.
+/// Matches C++ addSpan static function.
 fn add_span_internal(
     heightfield: &mut Heightfield,
     x: i32,
@@ -57,119 +55,100 @@ fn add_span_internal(
     area_id: u8,
     flag_merge_threshold: i32,
 ) -> Result<(), BuildError> {
-    // Get the column
-    let column_key = (x, z);
-    let column = heightfield.spans.entry(column_key).or_insert(None);
+    let col_idx = (x + z * heightfield.width) as usize;
+    let first = heightfield.columns[col_idx];
 
     // If column is empty, create first span
-    if column.is_none() {
-        let new_span = Rc::new(RefCell::new(Span {
+    if first == SPAN_NULL {
+        let idx = heightfield.alloc_span(SpanEntry {
             min: span_min,
             max: span_max,
             area: area_id,
-            next: None,
-        }));
-        *column = Some(new_span);
+            next: SPAN_NULL,
+        });
+        heightfield.columns[col_idx] = idx;
         return Ok(());
     }
 
     // Find position where to insert the span
-    let mut prev: Option<Rc<RefCell<Span>>> = None;
-    let mut current = column.clone();
+    let mut prev: SpanIndex = SPAN_NULL;
+    let mut current = first;
 
-    while let Some(span_rc) = current {
-        let span = span_rc.borrow();
+    while current != SPAN_NULL {
+        let cur = heightfield.spans[current as usize];
 
-        // Check for overlap
-        if span_max < span.min {
-            // Insert before current span
-            drop(span);
-            let new_span = Rc::new(RefCell::new(Span {
+        // No overlap: new span is entirely below current
+        if span_max < cur.min {
+            let new_idx = heightfield.alloc_span(SpanEntry {
                 min: span_min,
                 max: span_max,
                 area: area_id,
-                next: Some(span_rc.clone()),
-            }));
-
-            if let Some(prev_rc) = prev {
-                prev_rc.borrow_mut().next = Some(new_span);
+                next: current,
+            });
+            if prev != SPAN_NULL {
+                heightfield.spans[prev as usize].next = new_idx;
             } else {
-                *column = Some(new_span);
+                heightfield.columns[col_idx] = new_idx;
             }
             return Ok(());
         }
 
-        if span_min > span.max {
-            // Continue to next span
-            let next = span.next.clone();
-            drop(span);
-            prev = Some(span_rc);
-            current = next;
+        // No overlap: new span is entirely above current
+        if span_min > cur.max {
+            prev = current;
+            current = cur.next;
             continue;
         }
 
         // Spans overlap, merge them
-        let merged_min = span_min.min(span.min);
-        let mut merged_max = span_max.max(span.max);
-        let next = span.next.clone();
-        drop(span);
+        let merged_min = span_min.min(cur.min);
+        let mut merged_max = span_max.max(cur.max);
 
         // Determine merged area - match C++ logic exactly
-        // In C++, newSpan starts with the incoming area_id
         let mut merged_area = area_id;
-
-        // Only update area if max values are within threshold
-        let current_max = span_rc.borrow().max;
-        let current_area = span_rc.borrow().area;
-
-        if (merged_max as i32 - current_max as i32).abs() <= flag_merge_threshold {
-            // Higher area ID numbers indicate higher resolution priority
-            merged_area = merged_area.max(current_area);
+        if (merged_max as i32 - cur.max as i32).abs() <= flag_merge_threshold {
+            merged_area = merged_area.max(cur.area);
         }
 
         // Check if we need to merge with following spans
-        let mut next_span = next;
-        while let Some(next_rc) = next_span.clone() {
-            let next_borrow = next_rc.borrow();
-            if next_borrow.min > merged_max {
-                // No more overlaps
-                drop(next_borrow);
+        let mut next_span = cur.next;
+        while next_span != SPAN_NULL {
+            let ns = heightfield.spans[next_span as usize];
+            if ns.min > merged_max {
                 break;
             }
 
-            // Merge with next span — must also merge area (matching C++ addSpan)
-            let next_max = next_borrow.max;
-            let next_area = next_borrow.area;
-            merged_max = merged_max.max(next_max);
+            // Merge with next span
+            merged_max = merged_max.max(ns.max);
 
-            // Area merge: same threshold check as C++ for each overlapping span
-            if (merged_max as i32 - next_max as i32).abs() <= flag_merge_threshold {
-                merged_area = merged_area.max(next_area);
+            if (merged_max as i32 - ns.max as i32).abs() <= flag_merge_threshold {
+                merged_area = merged_area.max(ns.area);
             }
 
-            let following = next_borrow.next.clone();
-            drop(next_borrow);
+            let following = ns.next;
+            // Free the consumed span
+            heightfield.free_span(next_span);
             next_span = following;
         }
 
-        // Update or remove current span
-        span_rc.borrow_mut().min = merged_min;
-        span_rc.borrow_mut().max = merged_max;
-        span_rc.borrow_mut().area = merged_area;
-        span_rc.borrow_mut().next = next_span;
+        // Update current span with merged values
+        heightfield.spans[current as usize].min = merged_min;
+        heightfield.spans[current as usize].max = merged_max;
+        heightfield.spans[current as usize].area = merged_area;
+        heightfield.spans[current as usize].next = next_span;
 
         return Ok(());
     }
 
     // Add at end of list
-    if let Some(prev_rc) = prev {
-        let new_span = Rc::new(RefCell::new(Span {
+    if prev != SPAN_NULL {
+        let new_idx = heightfield.alloc_span(SpanEntry {
             min: span_min,
             max: span_max,
             area: area_id,
-            next: None,
-        }));
-        prev_rc.borrow_mut().next = Some(new_span);
+            next: SPAN_NULL,
+        });
+        heightfield.spans[prev as usize].next = new_idx;
     }
 
     Ok(())
@@ -524,13 +503,11 @@ mod tests {
             1.0,
         );
 
-        // Add a span
         add_span(&mut heightfield, 5, 5, 10, 20, 1, 1).unwrap();
 
-        // Check span was added
-        let column = heightfield.spans.get(&(5, 5)).unwrap();
-        assert!(column.is_some());
-        let span = column.as_ref().unwrap().borrow();
+        let si = heightfield.column_first_span(5, 5);
+        assert_ne!(si, SPAN_NULL);
+        let span = heightfield.span(si);
         assert_eq!(span.min, 10);
         assert_eq!(span.max, 20);
         assert_eq!(span.area, 1);
@@ -547,18 +524,14 @@ mod tests {
             1.0,
         );
 
-        // Add two overlapping spans
         add_span(&mut heightfield, 5, 5, 10, 20, 1, 1).unwrap();
         add_span(&mut heightfield, 5, 5, 15, 25, 2, 1).unwrap();
 
-        // Check spans were merged
-        let column = heightfield.spans.get(&(5, 5)).unwrap();
-        assert!(column.is_some());
-        let span = column.as_ref().unwrap().borrow();
+        let si = heightfield.column_first_span(5, 5);
+        assert_ne!(si, SPAN_NULL);
+        let span = heightfield.span(si);
         assert_eq!(span.min, 10);
         assert_eq!(span.max, 25);
-        // Area should be max of the two areas when within merge threshold
-        // C++ logic: max(1, 2) = 2
         assert_eq!(span.area, 2);
     }
 
@@ -581,13 +554,7 @@ mod tests {
         rasterize_triangle(&v0, &v1, &v2, 1, &mut heightfield, 1).unwrap();
 
         // Check that some spans were created
-        let mut has_spans = false;
-        for column in heightfield.spans.values() {
-            if column.is_some() {
-                has_spans = true;
-                break;
-            }
-        }
+        let has_spans = heightfield.columns().iter().any(|&si| si != SPAN_NULL);
         assert!(has_spans);
     }
 }

--- a/crates/recast/tests/pipeline_diagnostic.rs
+++ b/crates/recast/tests/pipeline_diagnostic.rs
@@ -75,17 +75,19 @@ fn run_pipeline_diagnostic(obj_name: &str) {
     let mut total_spans = 0u64;
     let mut walkable_spans = 0u64;
     let mut cells_with_spans = 0u64;
-    for (_coord, span_opt) in heightfield.spans() {
-        if let Some(first_span_rc) = span_opt {
-            cells_with_spans += 1;
-            let mut current = Some(first_span_rc.clone());
-            while let Some(span_rc) = current {
-                let span = span_rc.borrow();
+    for z in 0..heightfield.height() {
+        for x in 0..heightfield.width() {
+            let mut si = heightfield.column_first_span(x, z);
+            if si != recast::SPAN_NULL {
+                cells_with_spans += 1;
+            }
+            while si != recast::SPAN_NULL {
+                let s = heightfield.span(si);
                 total_spans += 1;
-                if span.area != 0 {
+                if s.area != 0 {
                     walkable_spans += 1;
                 }
-                current = span.next.clone();
+                si = s.next;
             }
         }
     }
@@ -419,16 +421,16 @@ fn pipeline_diagnostic_bridge() {
 fn count_walkable_spans(hf: &recast::Heightfield) -> (u64, u64) {
     let mut total = 0u64;
     let mut walkable = 0u64;
-    for (_coord, span_opt) in hf.spans() {
-        if let Some(first) = span_opt {
-            let mut current = Some(first.clone());
-            while let Some(span_rc) = current {
-                let span = span_rc.borrow();
+    for z in 0..hf.height() {
+        for x in 0..hf.width() {
+            let mut si = hf.column_first_span(x, z);
+            while si != recast::SPAN_NULL {
+                let s = hf.span(si);
                 total += 1;
-                if span.area != 0 {
+                if s.area != 0 {
                     walkable += 1;
                 }
-                current = span.next.clone();
+                si = s.next;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace `Heightfield` span storage from `HashMap<(i32,i32), Option<Rc<RefCell<Span>>>>` to a flat `columns: Vec<SpanIndex>` indexed by `x + z * width`, with spans in a contiguous arena (`Vec<SpanEntry>`) linked by `u32` indices
- Add freelist for span slot recycling during merges, matching C++'s pool allocator pattern
- Eliminate SipHash overhead, Rc reference counting, and RefCell runtime borrow checks
- Update all downstream consumers: compact_heightfield, convex_volume, heightfield_layers, rasterization, and 3 detour-dynamic files

## Performance

Median build time on nav_test.obj (10 iterations):

| Stage | Before | After | Change |
|-------|--------|-------|--------|
| Rasterize | 23.83ms | 10.97ms | -54% |
| Filter | 21.46ms | 2.37ms | -89% |
| Build Compact | 15.20ms | 12.04ms | -21% |
| **Total** | **72.33ms** | **44.70ms** | **-38%** |

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace` -- zero warnings
- [x] `cargo nextest run --workspace` -- 441 tests pass
- [x] nav_test.obj: 537 polys, 1197 verts (matches C++)
- [x] dungeon.obj: 217 polys, 452 verts (matches C++)
- [x] bridge.obj: 8 polys, 18 verts (matches C++)
- [x] Benchmark comparison shows no regression