### PR TITLE
feat(landmark): make context module and web-time dep optional

### DIFF
--- a/crates/landmark/Cargo.toml
+++ b/crates/landmark/Cargo.toml
@@ -16,7 +16,7 @@ landmark-common = { workspace = true }
 glam = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
-web-time = { workspace = true }
+web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_approx_eq = { workspace = true }
@@ -27,7 +27,8 @@ name = "generation"
 harness = false
 
 [features]
-default = []
+default = ["context"]
+context = ["dep:web-time"]
 
 [lints]
 workspace = true

--- a/crates/landmark/src/lib.rs
+++ b/crates/landmark/src/lib.rs
@@ -6,6 +6,7 @@
 mod area;
 mod compact_heightfield;
 mod config;
+#[cfg(feature = "context")]
 mod context;
 mod contour;
 mod convex_volume;
@@ -26,6 +27,7 @@ pub use area::{
 };
 pub use compact_heightfield::{CompactCell, CompactHeightfield, CompactSpan, RC_NOT_CONNECTED};
 pub use config::RecastConfig;
+#[cfg(feature = "context")]
 pub use context::{LogEntry, LogLevel, ProgressInfo, RecastContext, TimerCategory, TimerGuard};
 pub use contour::{BuildContoursFlags, Contour, ContourSet, ContourVertex};
 pub use convex_volume::{ConvexVolume, ConvexVolumeSet, MAX_CONVEX_VOLUME_VERTS};


### PR DESCRIPTION
## Summary

- Makes the `context` module (RecastContext, logging, timing) optional behind a `context` feature flag (enabled by default)
- Makes `web-time` an optional dependency, only pulled in when the `context` feature is active
- No behavior change for existing consumers (feature is on by default)

## Problem

The `context` module depends on `web-time`, which unconditionally pulls `wasm-bindgen` on `wasm32-unknown-unknown`. This makes landmark unusable in WASM environments that do not provide a JavaScript host (e.g., SpacetimeDB server modules), because the `wasm-bindgen` symbols are linked into the binary even though the context module is never used by the core mesh generation pipeline (`RecastBuilder::build_mesh` and friends don't take or construct a `RecastContext`).

## Solution

Gate the context module behind a `context` Cargo feature:

```toml
[features]
default = ["context"]
context = ["dep:web-time"]
```

Consumers targeting `wasm32-unknown-unknown` without JS can disable it:

```toml
landmark = { version = "...", default-features = false }
```

This removes the entire context module, web-time, and wasm-bindgen from the dependency tree while preserving all mesh generation, rasterization, and pathfinding functionality.

## Changes

- `crates/landmark/Cargo.toml`: `web-time` made optional, `context` feature added (default on)
- `crates/landmark/src/lib.rs`: `mod context` and `pub use context::*` gated with `#[cfg(feature = "context")]`

## Testing

- `cargo test -p landmark` (default features): all tests pass
- `cargo test -p landmark --no-default-features`: all tests pass
- No other crate in the workspace references context types (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)