### PR TITLE
fix(ci): fall back to landmark-cli when BINARY_DEFAULT var is unset

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -45,6 +45,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
+    env:
+      BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT || 'landmark-cli' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -74,23 +76,17 @@ jobs:
 
       - name: Build with cross for ${{ matrix.target }}
         if: matrix.cross
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           cross build --target "${{ matrix.target }}" --release --bin "${BINARY_DEFAULT}"
 
       - name: Build natively for ${{ matrix.target }}
         if: '!matrix.cross'
         shell: bash
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           cargo build --target "${{ matrix.target }}" --release --bin "${BINARY_DEFAULT}"
 
       - name: Verify build artifacts exist
         shell: bash
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           if [[ "${{ matrix.target }}" == *"windows"* ]]; then
             ls -la "target/${{ matrix.target }}/release/${BINARY_DEFAULT}.exe" || true
@@ -103,5 +99,5 @@ jobs:
         with:
           name: build-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ vars.BINARY_DEFAULT }}*
+            target/${{ matrix.target }}/release/${{ env.BINARY_DEFAULT }}*
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- Hoist `BINARY_DEFAULT` to a job-level env with a `'landmark-cli'` fallback so fork PRs no longer fail the Cross-Platform Build job.
- Remove the per-step `env:` duplicates now that the value lives at job scope.
- Switch the artifact `path:` expression from `vars.BINARY_DEFAULT` to `env.BINARY_DEFAULT` so it picks up the fallback too.

## Problem

Fork PRs do not have access to repository variables. On a fork PR run, `vars.BINARY_DEFAULT` expanded to an empty string and the workflow invoked `cargo build --bin ""` / `cross build --bin ""`, failing with:

```
error: no bin target named `` in default-run packages
available bin targets: landmark-cli
```

This surfaced on #19 (from a fork) even though the PR's changes only touched the `landmark` crate's feature gating. Diagnosis credit: @PedroSoutoDev.

## Test plan

- [ ] Cross-Platform Build job passes on this PR (internal branch, `vars.BINARY_DEFAULT` present — should resolve normally).
- [ ] Confirm a future fork PR no longer hits the empty-bin failure (will need a real fork PR to fully verify, but the fallback is visible in the workflow file).