### PR TITLE
feat(landmark): disable context feature by default + fix CI fork fallback

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -45,6 +45,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
+    env:
+      BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT || 'landmark-cli' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -74,23 +76,17 @@ jobs:
 
       - name: Build with cross for ${{ matrix.target }}
         if: matrix.cross
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           cross build --target "${{ matrix.target }}" --release --bin "${BINARY_DEFAULT}"
 
       - name: Build natively for ${{ matrix.target }}
         if: '!matrix.cross'
         shell: bash
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           cargo build --target "${{ matrix.target }}" --release --bin "${BINARY_DEFAULT}"
 
       - name: Verify build artifacts exist
         shell: bash
-        env:
-          BINARY_DEFAULT: ${{ vars.BINARY_DEFAULT }}
         run: |
           if [[ "${{ matrix.target }}" == *"windows"* ]]; then
             ls -la "target/${{ matrix.target }}/release/${BINARY_DEFAULT}.exe" || true
@@ -103,5 +99,5 @@ jobs:
         with:
           name: build-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ vars.BINARY_DEFAULT }}*
+            target/${{ matrix.target }}/release/${{ env.BINARY_DEFAULT }}*
           if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ categories = ["game-development", "algorithms"]
 [workspace.dependencies]
 # Internal workspace dependencies
 landmark-common = { path = "crates/landmark-common", version = "0.1.0" }
-landmark = { path = "crates/landmark", version = "0.1.0" }
+landmark = { path = "crates/landmark", version = "0.1.0", default-features = false }
 waymark = { path = "crates/waymark", version = "0.1.0" }
 waymark-crowd = { path = "crates/waymark-crowd", version = "0.1.0" }
 waymark-tilecache = { path = "crates/waymark-tilecache", version = "0.1.0" }


### PR DESCRIPTION
## Summary

- Sets `default-features = false` on the workspace-level `landmark` dependency, removing `web-time` (and transitively `wasm-bindgen`) from every crate that inherits `landmark = { workspace = true }`
- Hoists `BINARY_DEFAULT` to a job-level env with a `'landmark-cli'` fallback so fork PRs no longer fail the Cross-Platform Build job (rolls in #20)
- Updates `lz4_flex` 0.12.0 → 0.12.1 to fix RUSTSEC-2026-0041 (information leak in LZ4 block decompression) and resolve the yanked crate warning

## Motivation

**Workspace default-features** — Follow-up to #19. That PR made `web-time` optional behind a `context` feature flag, but the workspace dependency still enabled default features. Consumers like `waymark` that compile to `wasm32-unknown-unknown` without a JS host (e.g., SpacetimeDB server modules) still pulled in `web-time` → `wasm-bindgen` transitively, requiring a stub workaround. No workspace member uses the context module (`RecastContext`, timing, logging) — verified via grep.

After this change, `cargo tree -p waymark | grep web-time` returns nothing.

**CI fork fallback** — Fork PRs do not have access to repository variables. `vars.BINARY_DEFAULT` expanded to an empty string, causing `cargo build --bin ""` to fail. The fix hoists the env to job scope with a `'landmark-cli'` fallback, removes per-step duplicates, and switches the artifact `path:` from `vars` to `env`.

**lz4_flex advisory** — `lz4_flex` 0.12.0 is yanked and flagged by RUSTSEC-2026-0041 for leaking uninitialized memory or reused buffer contents during LZ4 block decompression with invalid offsets. Bumped to 0.12.1 via `cargo update -p lz4_flex`.

## Changes

1. `Cargo.toml`: `landmark` workspace dep → `default-features = false`
2. `.github/workflows/cross-build.yml`: job-level env with fallback, remove per-step env blocks, fix artifact path expression
3. `Cargo.lock`: `lz4_flex` 0.12.0 → 0.12.1

## Testing

- `cargo test --workspace` — all tests pass
- `cargo tree -p waymark` — no `web-time` in the tree
- `cargo update -p lz4_flex` resolves the advisory

Supersedes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)